### PR TITLE
Thorough style audit.

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -1,8 +1,19 @@
 AllCops:
   Exclude:
-    - "vendor/**/*"
-    - "db/schema.rb"
+    - 'vendor/**/*'
+    - 'db/schema.rb'
+    - 'Guardfile'
   UseCache: false
+Style/EmptyLinesAroundClassBody:
+  Enabled: false
+Style/EmptyLinesAroundModuleBody:
+  Enabled: false
+Style/ExtraSpacing:
+  Enabled: true
+  Exclude: ['Gemfile']
+Style/ClassAndModuleChildren:
+  EnforcedStyle: nested
+  Exclude: ['test/test_helper.rb']
 Style/CollectionMethods:
   Description: Preferred collection methods.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -5,31 +5,31 @@ module API
       include ActionController::MimeResponds
 
       def context
-        {current_user: current_user}
+        { current_user: current_user }
       end
 
       private
 
-        def restrict_access
-          unless restrict_access_by_params || restrict_access_by_header
-            render json: {message: 'Invalid API token.'}, status: 401
-            return
-          end
-
-          @current_user = @api_key.user if @api_key
+      def restrict_access
+        unless restrict_access_by_params || restrict_access_by_header
+          render json: { message: 'Invalid API token.' }, status: 401
+          return
         end
 
-        def restrict_access_by_header
-          return true if @api_key
-          authenticate_with_http_token { |token|
-            @api_key = APIKey.find_by(token: token)
-          }
-        end
+        @current_user = @api_key.user if @api_key
+      end
 
-        def restrict_access_by_params
-          return true if @api_key
-          @api_key = APIKey.find_by(token: params[:api_key])
-        end
+      def restrict_access_by_header
+        return true if @api_key
+        authenticate_with_http_token { |token|
+          @api_key = APIKey.find_by(token: token)
+        }
+      end
+
+      def restrict_access_by_params
+        return true if @api_key
+        @api_key = APIKey.find_by(token: params[:api_key])
+      end
 
     end
   end

--- a/app/controllers/api/v1/developments_controller.rb
+++ b/app/controllers/api/v1/developments_controller.rb
@@ -6,16 +6,16 @@ module API
 
       private
 
-        def log_search
-          if filter_params.keys.any?
-            user = current_user || User.null
-            Search.create!(query: filter_params, user: user)
-          end
+      def log_search
+        if filter_params.keys.any?
+          user = current_user || User.null
+          Search.create!(query: filter_params, user: user)
         end
+      end
 
-        def filter_params
-          params.fetch(:filter) { Hash.new }
-        end
+      def filter_params
+        params.fetch(:filter) { Hash.new }
+      end
 
     end
   end

--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -8,9 +8,9 @@ module API
 
       private
 
-        def search_params
-          params.permit(:api_key)
-        end
+      def search_params
+        params.permit(:api_key)
+      end
 
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,11 +4,13 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   protected
-    def authenticate_user!(options={})
-      if user_signed_in?
-        super
-      else
-        redirect_to '/users/sign_in'
-      end
+
+  def authenticate_user!(options = {})
+    if user_signed_in?
+      super
+    else
+      redirect_to '/users/sign_in'
     end
+  end
+
 end

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -11,11 +11,10 @@ class ClaimsController < ApplicationController
     @claim.assign_attributes(development: @development, claimant: current_user)
     if @claim.save
       flash[:success] = CLAIM_CREATED
-      redirect_to @development
     else
-      flash[:danger] = @claim.errors.full_messages #CLAIM_NOT_CREATED
-      redirect_to @development
+      flash[:danger] = @claim.errors.full_messages # CLAIM_NOT_CREATED
     end
+    redirect_to @development
   end
 
   def index
@@ -24,21 +23,21 @@ class ClaimsController < ApplicationController
 
   private
 
-    def load_parent
-      @development = Development.find params[:development_id]
-    end
+  def load_parent
+    @development = Development.find params[:development_id]
+  end
 
-    def new_claim_params
-      params.require(:claim).permit(:role)
-    end
+  def new_claim_params
+    params.require(:claim).permit(:role)
+  end
 
-    CLAIM_CREATED = """
-      Thanks! We received your claim and will address it within 5-10 business days.
-    """
+  CLAIM_CREATED = '''
+    Thanks! We received your claim and will address it within 5-10 business days.
+  '''
 
-    CLAIM_NOT_CREATED = """
-      Sorry, we were unable to accept your claim. Please contact
-      us if you think this message is in error.
-    """
+  CLAIM_NOT_CREATED = """
+    Sorry, we were unable to accept your claim. Please contact
+    us if you think this message is in error.
+  """
 
 end

--- a/app/controllers/developments_controller.rb
+++ b/app/controllers/developments_controller.rb
@@ -17,10 +17,10 @@ class DevelopmentsController < ApplicationController
     # the form and not acting on the development itself.
     form = DevelopmentForm.new(current_user)
     if form.submit(@development.id, edit_development_params)
-      flash[:partial] = { path: "developments/proposed_success" }
+      flash[:partial] = { path: 'developments/proposed_success' }
       redirect_to @development
     else
-      flash[:partial] = { path: "developments/proposed_error" }
+      flash[:partial] = { path: 'developments/proposed_error' }
       redirect_to edit_development_path(@development)
     end
   end
@@ -30,24 +30,25 @@ class DevelopmentsController < ApplicationController
 
   private
 
-    def load_record
-      @development = DevelopmentPresenter.new(
-        Development.find(params[:id])
-      )
-    end
+  def load_record
+    @development = DevelopmentPresenter.new(
+      Development.find(params[:id])
+    )
+  end
 
-    def development_params
-      params.require(:development).permit(:name)
-    end
+  def development_params
+    params.require(:development).permit(:name)
+  end
 
-    def edit_development_params
-      params.require(:development).permit(
-        :name, :total_cost, :rdv, :address, :city, :state, :zip_code,
-        :status
-      )
-    end
+  def edit_development_params
+    params.require(:development).permit(
+      :name, :total_cost, :rdv, :address, :city, :state, :zip_code,
+      :status
+    )
+  end
 
-    def search_params
-      params.fetch(:q) { Hash.new }
-    end
+  def search_params
+    params.fetch(:q) { Hash.new }
+  end
+
 end

--- a/app/controllers/edits_controller.rb
+++ b/app/controllers/edits_controller.rb
@@ -16,50 +16,52 @@ class EditsController < ApplicationController
 
   private
 
-    def moderate(moderator_class, object, partial_ref)
-      if moderator_class.new(object).perform!
-        obj = partial_object(partial_ref)
-        obj[:object][:none_left] = true if object.development.pending_edits.empty?
-        flash[:partial] = obj
-        redirect_to :pending_development_edits
-      else
-        default_rescue_action(object)
-      end
+  def moderate(moderator_class, object, partial_ref)
+    if moderator_class.new(object).perform!
+      obj = partial_object(partial_ref)
+      obj[:object][:none_left] = true if object.development.pending_edits.empty?
+      flash[:partial] = obj
+      redirect_to :pending_development_edits
+    else
+      default_rescue_action(object)
     end
+  end
 
-    def load_parent
-      @development = DevelopmentPresenter.new(
-        Development.find(params[:development_id])
-      )
-    end
+  def load_parent
+    @development = DevelopmentPresenter.new(
+      Development.find(params[:development_id])
+    )
+  end
 
-    def load_unmoderated_record
-      @edit = EditPresenter.new(Edit.find(params[:id]))
-      if @edit.moderated?
-        # TODO Test this.
-        flash[:error] = "The edit you were trying to moderate has already been #{@edit.state}."
-        redirect_to :pending_development_edits
-      end
-    end
-
-    def default_rescue_action(object)
-      # TODO: Trigger Airbrake error notices
-      flash[:partial] = claim_not_acted_upon
-      redirect_to :pending_development_edits, status: 400
-    end
-
-    def partial_object(action)
-      { path: "edits/action", object:
-        { action: action, name: @edit.editor.first_name }}
-    end
-
-    def error_partial(message)
-      { path: "unexpected_error", object: { message: message } }
-    end
-
-    def claim_not_acted_upon
-      error_partial """
-        As a result, the edit you were trying to resolve may not be resolved.
+  def load_unmoderated_record
+    @edit = EditPresenter.new(Edit.find(params[:id]))
+    if @edit.moderated?
+      # TODO: Test this.
+      flash[:error] = """
+        The edit you were trying to moderate has already been #{@edit.state}.
       """
+      redirect_to :pending_development_edits
     end
+  end
+
+  def default_rescue_action(object)
+    # TODO: Trigger Airbrake error notices
+    flash[:partial] = claim_not_acted_upon
+    redirect_to :pending_development_edits, status: 400
+  end
+
+  def partial_object(action)
+    { path: 'edits/action', object:
+      { action: action, name: @edit.editor.first_name }}
+  end
+
+  def error_partial(message)
+    { path: 'unexpected_error', object: { message: message } }
+  end
+
+  def claim_not_acted_upon
+    error_partial '''
+      As a result, the edit you were trying to resolve may not be resolved.
+    '''
+  end
 end

--- a/app/controllers/flags_controller.rb
+++ b/app/controllers/flags_controller.rb
@@ -25,24 +25,24 @@ class FlagsController < ApplicationController
 
   private
 
-    def load_parent
-      @development = Development.find params[:development_id]
-    end
+  def load_parent
+    @development = Development.find params[:development_id]
+  end
 
-    def new_flag_params
-      params.require(:flag).permit(:reason)
-    end
+  def new_flag_params
+    params.require(:flag).permit(:reason)
+  end
 
-    FLAG_CREATED = """
-      Thanks! We received your flag and will address it shortly.
-    """
+  FLAG_CREATED = '''
+    Thanks! We received your flag and will address it shortly.
+  '''
 
-    FLAG_NOT_CREATED = """
-      Sorry, we were unable to accept your flag.
-    """
+  FLAG_NOT_CREATED = '''
+    Sorry, we were unable to accept your flag.
+  '''
 
-    DEFAULT_REASON = "Why are you flagging this development?
-      A quick explanation (23-450 characters) will
-      help us address it much more quickly.".gsub(/\s{2,}/, ' ')
+  DEFAULT_REASON = "Why are you flagging this development?
+    A quick explanation (23-450 characters) will
+    help us address it much more quickly.".gsub(/\s{2,}/, ' ')
 
 end

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -24,7 +24,8 @@ class MembershipsController < ApplicationController
   end
 
   private
-    def membership_params
-      params.permit(:membership_id, :user_id, :organization_id, :id)
-    end  
+
+  def membership_params
+    params.permit(:membership_id, :user_id, :organization_id, :id)
+  end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -39,11 +39,12 @@ class OrganizationsController < ApplicationController
   end
 
   private
-    def org_params
-      params.require(:organization).permit(:name, :email, :location, :short_name, :website, :abbv)
-    end  
 
-    def load_presented_record
-      @organization = OrganizationPresenter.new(Organization.find(params[:id]))
-    end
+  def org_params
+    params.require(:organization).permit(:name, :email, :location, :short_name, :website, :abbv)
+  end
+
+  def load_presented_record
+    @organization = OrganizationPresenter.new(Organization.find(params[:id]))
+  end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -2,15 +2,15 @@ class RegistrationsController < Devise::RegistrationsController
 
   private
 
-    def update_resource(resource, params)
-      resource.update_without_password(params)
-    end
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
 
-    def sign_up_params
-      params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation)
-    end
+  def sign_up_params
+    params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation)
+  end
 
-    def account_update_params
-      params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation, :current_password)
-    end
+  def account_update_params
+    params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation, :current_password)
+  end
 end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -18,7 +18,15 @@ class SearchesController < ApplicationController
     { pdf:   @search.id.to_s,
       title: @search.title.to_s,
       layout: 'pdf',
-      template: 'searches/show.html.haml' }
+      template: 'searches/show.html.haml',
+      header: { right: '[page] of [topage]', font_size: 9 },
+      footer: {
+        # TODO MAPC Logo
+        left: "Generated on #{Time.now.to_s(:timestamp)}",
+        right: 'mapc.org',
+        font_size: 9
+      }
+    }
   end
 
   def disposition

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -4,13 +4,25 @@ class SearchesController < ApplicationController
   before_action :ensure_saved_search
 
   def show
-    render pdf: "#{@search.id}",
-         title: "#{@search.title}",
-         show_as_html: params[:format] == 'html',
-             template: 'searches/show.html.haml'
+    respond_to do |format|
+      format.pdf  { render pdf_options }
+      format.html { render pdf_options.merge({ show_as_html: true }) }
+      format.csv  { send_data @search.to_csv, type: Mime::CSV,
+        disposition: disposition }
+    end
   end
 
   private
+
+  def pdf_options
+    { pdf:   @search.id.to_s,
+      title: @search.title.to_s,
+      template: 'searches/show.html.haml' }
+  end
+
+  def disposition
+    "attachment; filename=#{@search.title.parameterize}.csv"
+  end
 
   def load_record
     @search = ReportPresenter.new(Search.find(params[:id]))

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -12,15 +12,15 @@ class SearchesController < ApplicationController
 
   private
 
-    def load_record
-      @search = ReportPresenter.new(Search.find(params[:id]))
-    end
+  def load_record
+    @search = ReportPresenter.new(Search.find(params[:id]))
+  end
 
-    def ensure_saved_search
-      search = @search.item
-      if search.unsaved?
-        search.saved = true
-        search.save!
-      end
+  def ensure_saved_search
+    search = @search.item
+    if search.unsaved?
+      search.saved = true
+      search.save!
     end
+  end
 end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -17,6 +17,7 @@ class SearchesController < ApplicationController
   def pdf_options
     { pdf:   @search.id.to_s,
       title: @search.title.to_s,
+      layout: 'pdf',
       template: 'searches/show.html.haml' }
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,8 @@ class UsersController < ApplicationController
   end
 
   private
-    def user_params
-      params.require(:user).permit(:name, :email, :first_name, :last_name)
-    end
+
+  def user_params
+    params.require(:user).permit(:name, :email, :first_name, :last_name)
+  end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -14,13 +14,13 @@ class Claim < ActiveRecord::Base
 
   enumerize :role, :in => DevelopmentTeamMembership.role.options
 
-  def approve!(options={})
+  def approve!(options = {})
     if approve(options)
       self.save
     end
   end
 
-  def approve(options={})
+  def approve(options = {})
     self.reason = options.fetch(:reason) { nil }
     assert_valid_moderator(options)
     # TODO: Assign claimant as desired role on project.
@@ -31,7 +31,7 @@ class Claim < ActiveRecord::Base
     self.state = :approved
   end
 
-  def deny!(options={})
+  def deny!(options = {})
     if deny(options)
       self.save
     end

--- a/app/models/development.rb
+++ b/app/models/development.rb
@@ -1,5 +1,5 @@
 class Development < ActiveRecord::Base
-  # TODO basic geocoding
+  # TODO: basic geocoding
   # geocoded_by :full_street_address   # Implement this method
   # after_validation :geocode          # Auto-fetch coordinates
   has_one :walkscore # TODO

--- a/app/models/edit.rb
+++ b/app/models/edit.rb
@@ -15,7 +15,7 @@ class Edit < ActiveRecord::Base
   enumerize :state, in: [:pending, :approved, :declined],
     default: :pending, predicates: true
 
-  # TODO Do these belong here, if the service is handling
+  # TODO: Do these belong here, if the service is handling
   # the alteration of state?
   def approved
     assign_attributes(moderated_at: Time.now, state: :approved)

--- a/app/models/verification.rb
+++ b/app/models/verification.rb
@@ -1,6 +1,6 @@
 class Verification < ActiveRecord::Base
   extend Enumerize
-  # TODO Should be polymorph-ish. Basically, while it should belong
+  # TODO: Should be polymorph-ish. Basically, while it should belong
   # to user (because a person must request it), they can also
   # request it on behalf of an organization.
 
@@ -15,7 +15,7 @@ class Verification < ActiveRecord::Base
     default: :pending, predicates: true
 
   def verifiable?
-    # TODO [Code Smell] Multiple calls to valid_verifier?
+    # TODO: [Code Smell] Multiple calls to valid_verifier?
     # are already getting confusing.
     valid? && eligible_user? && valid_verifier?
   end
@@ -51,7 +51,7 @@ class Verification < ActiveRecord::Base
       end
     end
 
-    # TODO [Code Smell] Should these be validations?
+    # TODO: [Code Smell] Should these be validations?
     def eligible_user?
       user.present? # TODO: user.verifiable?
     end

--- a/app/presenters/change_presenter.rb
+++ b/app/presenters/change_presenter.rb
@@ -12,9 +12,9 @@ class ChangePresenter < Burgundy::Item
       template_for(types.first.name.to_sym)
     end
 
-    # TODO Make this return an object, for the template
+    # TODO: Make this return an object, for the template
     # to lay out and interpolate text.
-    # TODO For enumerized statuses, instead of just checking
+    # TODO: For enumerized statuses, instead of just checking
     # that it's String type, titleize values. That is, in_construction,
     # should read In Construction.
     def template_for(type)

--- a/app/presenters/development_presenter.rb
+++ b/app/presenters/development_presenter.rb
@@ -34,7 +34,7 @@ class DevelopmentPresenter < Burgundy::Item
 
   # Nearby or similar developments
   def related
-    # TODO make nearby / similar, instead of a simple limit
+    # TODO: make nearby / similar, instead of a simple limit
     DevelopmentPresenter.wrap Development.limit(3)
   end
 
@@ -51,7 +51,7 @@ class DevelopmentPresenter < Burgundy::Item
      [:tothu, :commsf, :prjarea, :stories, :height]
    end
 
-  def display_address(options={})
+  def display_address(options = {})
     options[:short] ? short_address : long_address
   end
 

--- a/app/presenters/report_presenter.rb
+++ b/app/presenters/report_presenter.rb
@@ -47,6 +47,10 @@ class ReportPresenter < Burgundy::Item
     query
   end
 
+  def to_csv
+    DevelopmentsSerializer.new(developments).to_csv
+  end
+
   private
 
     def prepare_statuses

--- a/app/serializers/development_serializer.rb
+++ b/app/serializers/development_serializer.rb
@@ -1,6 +1,6 @@
 class DevelopmentSerializer
 
-  def initialize(record, options={})
+  def initialize(record, options = {})
     @record  = record
     @options = options
   end

--- a/app/serializers/development_team_serializer.rb
+++ b/app/serializers/development_team_serializer.rb
@@ -7,7 +7,7 @@ class DevelopmentTeamSerializer
     @row = Array.new(@max_team_size * team_attributes_count)
   end
 
-  # TODO Refactor and clean up
+  # TODO: Refactor and clean up
   def to_row
     # Get attributes from all of the team members
     values = @development.team_memberships.map { |team_membership|

--- a/app/services/tagline_generator.rb
+++ b/app/services/tagline_generator.rb
@@ -1,5 +1,5 @@
 class TaglineGenerator
-  def initialize(source, options={})
+  def initialize(source, options = {})
     @source = source
   end
 

--- a/app/views/claims/new.html.haml
+++ b/app/views/claims/new.html.haml
@@ -11,9 +11,9 @@
         .eight.wide.field
           = f.label :role, "What role does this organization play on the developent team?"
           = f.select :role, Claim.role.options
-        -# TODO Add more instructions.
-        -# TODO Of your organizations, which are you claiming?
-        -# TODO Add :organization to Claim
+        -# TODO: Add more instructions.
+        -# TODO: Of your organizations, which are you claiming?
+        -# TODO: Add :organization to Claim
         -# .eight.wide.field
           -# = f.label :organization
           -# = f.select :organization, current_user organization options

--- a/app/views/developments/show/_actions.html.haml
+++ b/app/views/developments/show/_actions.html.haml
@@ -3,7 +3,7 @@
   %br
   .ui.dropdown.icon.button#subscribe
     %i.unhide.icon
-    -# TODO Add label for # of watchers
+    -# TODO: Add label for # of watchers
     %span.text Watch
     .menu
       .item
@@ -19,7 +19,7 @@
 
   -# Consider making this a partial, passing the path, icon, and text
 
-  -# TODO Can edit if ... ?
+  -# TODO: Can edit if ... ?
   =link_to edit_development_path(@development) do
     .ui.vertical.animated.button{:tabindex => "0"}
       .visible.content
@@ -27,7 +27,7 @@
       .hidden.content
         Edit
 
-  -# TODO Can flag if you are signed in.
+  -# TODO: Can flag if you are signed in.
   =link_to new_development_flag_path(@development) do
     .ui.vertical.animated.button{:tabindex => "0"}
       .visible.content
@@ -35,7 +35,7 @@
       .hidden.content
         Flag
 
-  -# TODO Can claim if you belong to at least one organization.
+  -# TODO: Can claim if you belong to at least one organization.
   =link_to new_development_claim_path(@development) do
     .ui.vertical.animated.button{:tabindex => "0"}
       .visible.content

--- a/app/views/developments/show/_status.html.haml
+++ b/app/views/developments/show/_status.html.haml
@@ -1,4 +1,4 @@
--# TODO Make this a view helper or lookup
+-# TODO: Make this a view helper or lookup
 - if @development.completed?
   .ui.label.large.basic
     %i.icon.checkmark

--- a/app/views/developments/show/_tags.html.haml
+++ b/app/views/developments/show/_tags.html.haml
@@ -1,4 +1,4 @@
--# TODO make this a view helper
+-# TODO: make this a view helper
 - if @development.private?
   .ui.teal.basic.label   Draft
 - if @development.private?

--- a/app/views/flashes/developments/_proposed_success.html.haml
+++ b/app/views/flashes/developments/_proposed_success.html.haml
@@ -4,4 +4,4 @@
     Thanks!
   %p
     Your proposed changes have been submitted for moderation.
-    -# TODO A moderator has been notified.
+    -# TODO: A moderator has been notified.

--- a/app/views/layouts/pdf.html.haml
+++ b/app/views/layouts/pdf.html.haml
@@ -1,11 +1,15 @@
 !!!5
 %html
   %head
-    - %i( reset site header icon list table ).each do |file|
+    = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.0/jquery.min.js'
+
+    - %i( reset site icon list table ).each do |file|
+      = stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.8/components/#{file}.min.css"
       = javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.8/components/#{file}.min.js"
+
+    - %i( header ).each do |file|
       = stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.8/components/#{file}.min.css"
 
-    = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.0/jquery.min.js'
     = stylesheet_link_tag    'http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css'
     = javascript_include_tag 'http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js'
 

--- a/app/views/layouts/pdf.html.haml
+++ b/app/views/layouts/pdf.html.haml
@@ -1,0 +1,16 @@
+!!!5
+%html
+  %head
+    - %i( reset site header icon list table ).each do |file|
+      = javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.8/components/#{file}.min.js"
+      = stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.8/components/#{file}.min.css"
+
+    = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.0/jquery.min.js'
+    = stylesheet_link_tag    'http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css'
+    = javascript_include_tag 'http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js'
+
+  %body
+    #main.ui.main.grid.container
+      .row
+        .column
+          = yield

--- a/app/views/searches/show.html.haml
+++ b/app/views/searches/show.html.haml
@@ -44,11 +44,7 @@
           - if stat.fetch(:count) == 0
             %td -
           - else
-            %td
-              = stat.fetch(field)
-              (
-              = stat.fetch(field) / stat.fetch(:count).to_f
-              \%)
+            %td #{stat.fetch(field)} (#{stat.fetch(field) / stat.fetch(:count).to_f}%)
 
 
 #footer
@@ -75,12 +71,20 @@
 :javascript
 
   var map = L.map('map', { zoomControl:false }).setView([42.359,-71.137], 10);
+  const ATTRIBUTION = 'Map tiles by <a href="http://mapc.org">MAPC</a>, ' +
+                  'Data by <a href="http://www.mass.gov/mgis/">MassGIS</a>.';
 
-  L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-      attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+  L.tileLayer('http://tiles.mapc.org/basemap/{z}/{x}/{y}.png', {
+    minZoom: 9,
+    maxZoom: 17,
+    attribution: ATTRIBUTION
   }).addTo(map);
 
-  #{
+  var markers = [#{
     @search.results.map(&:location)
-      .map { |loc| "L.marker(#{loc.reverse.map(&:to_f)}).addTo(map)" }.join("\n")
-  }
+      .map { |loc| "L.marker(#{loc.reverse.map(&:to_f)})" }.join(', ')
+  }]
+
+  var group = new L.featureGroup(markers).addTo(map);
+
+  map.fitBounds(group.getBounds());

--- a/app/views/searches/show.html.haml
+++ b/app/views/searches/show.html.haml
@@ -1,83 +1,71 @@
-!!!5
-- %i( reset site header icon list table ).each do |file|
-  = javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.8/components/#{file}.min.js"
-  = stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.8/components/#{file}.min.css"
+%h1.ui.header.page-header
+  = @search.title
 
-= stylesheet_link_tag 'http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css'
-= javascript_include_tag 'http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js'
+#map{style: 'height: 360px; width: 750px;'}
 
-= javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.0/jquery.min.js'
-
-.ui.container
-  %h1.ui.header.page-header
-    = @search.title
-
-  #map{style: 'height: 360px; width: 750px;'}
-
-  %table.ui.celled.table.unstackable
-    %thead
+%table.ui.celled.table.unstackable
+  %thead
+    %tr
+      %th
+      - @search.status_keys.each do |name|
+        %th= name.titleize
+  %tbody
+    %tr
+      %td Number of projects
+      - @search.status_keys.each do |key|
+        %td= @search.statuses.send(key).fetch(:count)
+    - @search.numeric_fields.each do |field|
       %tr
-        %th
-        - @search.status_keys.each do |name|
-          %th= name.titleize
-    %tbody
-      %tr
-        %td Number of projects
+        %td= Development.human_attribute_name field
         - @search.status_keys.each do |key|
-          %td= @search.statuses.send(key).fetch(:count)
-      - @search.numeric_fields.each do |field|
-        %tr
-          %td= Development.human_attribute_name field
-          - @search.status_keys.each do |key|
-            - stat = @search.statuses.send(key)
-            - if stat.fetch(:count) == 0
-              %td -
-            - else
-              %td= stat.fetch(field) { '-' }
+          - stat = @search.statuses.send(key)
+          - if stat.fetch(:count) == 0
+            %td -
+          - else
+            %td= stat.fetch(field) { '-' }
 
 
-  %table.ui.celled.table.unstackable
-    %thead
+%table.ui.celled.table.unstackable
+  %thead
+    %tr
+      %th
+      - @search.status_keys.each do |name|
+        %th= name.titleize
+  %tbody
+    %tr
+      %td Number of projects
+      - @search.status_keys.each do |key|
+        %td= @search.statuses.send(key).fetch(:count)
+    - @search.boolean_fields.each do |field|
       %tr
-        %th
-        - @search.status_keys.each do |name|
-          %th= name.titleize
-    %tbody
-      %tr
-        %td Number of projects
+        %td= Development.human_attribute_name field
         - @search.status_keys.each do |key|
-          %td= @search.statuses.send(key).fetch(:count)
-      - @search.boolean_fields.each do |field|
-        %tr
-          %td= Development.human_attribute_name field
-          - @search.status_keys.each do |key|
-            - stat = @search.statuses.send(key)
-            - if stat.fetch(:count) == 0
-              %td -
-            - else
-              %td
-                = stat.fetch(field)
-                (
-                = stat.fetch(field) / stat.fetch(:count).to_f
-                \%)
+          - stat = @search.statuses.send(key)
+          - if stat.fetch(:count) == 0
+            %td -
+          - else
+            %td
+              = stat.fetch(field)
+              (
+              = stat.fetch(field) / stat.fetch(:count).to_f
+              \%)
 
 
 #footer
-%br
-%p
-  Generated on
-  = Time.now.to_s(:timestamp)
+  %p
+    Generated on
+    = Time.now.to_s(:timestamp)
 
-%p
-  Criteria used:
+  %p
+    Criteria used:
 
-%ul
-  - @search.criteria.each do |field, v|
-    %li #{Development.human_attribute_name(field)} = #{v}
+  %ul
+    - @search.criteria.each do |field, v|
+      %li #{Development.human_attribute_name(field)} = #{v}
 
-%p
-  View the latest version of this report at
-  = link_to search_url(@search), @search
+  %p
+    View the latest version of this report at
+    = link_to search_url(@search), @search
 
 -# TODO: Above link is to PDF, not to live search results.
 -#   I think we should link to the client with the live HTML results

--- a/app/views/searches/show.html.haml
+++ b/app/views/searches/show.html.haml
@@ -79,10 +79,10 @@
   View the latest version of this report at
   = link_to search_url(@search), @search
 
--# TODO Above link is to PDF, not to live search results.
+-# TODO: Above link is to PDF, not to live search results.
 -#   I think we should link to the client with the live HTML results
 -#   from this search (maybe link to developments/search?query=) and/or
--# TODO Provide a link to DD itself from here.
+-# TODO: Provide a link to DD itself from here.
 
 :javascript
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ require 'api_constraints'
 Rails.application.routes.draw do
 
   namespace :api, constraints: {subdomain: 'api'}, path: '' do
-    api_version( # TODO Move all this into an APIVersion class
+    api_version( # TODO: Move all this into an APIVersion class
       module: "V1",
       header: {name: "Accept",
         value: "application/vnd.api+json; application/org.dd.v1"},

--- a/lib/range_parser.rb
+++ b/lib/range_parser.rb
@@ -6,12 +6,12 @@ module RangeParser
 
   def self.parse(value)
     @value = value
-    return self.infinity_range if !@value.present?
+    return infinity_range unless @value.present?
     if @value.is_a? Array
       return parse_rejoined_string if @value.first.is_a?(String)
       Range.new *@value.map(&:to_f)
     else
-      self.parse_string
+      parse_string
     end
   end
 
@@ -19,7 +19,7 @@ module RangeParser
 
   def self.parse_rejoined_string
     @value = @value.join ','
-    self.parse_string
+    parse_string
   end
 
   def self.parse_string

--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -103,7 +103,7 @@ end
 #   address     = "#{Faker::Address.street_address}, #{Faker::Address.city} #{Faker::Address.state_abbr} #{Faker::Address.zip}"
 #   status      = [:projected, :planning, :in_construction, :completed].sample
 #   total_cost  = Faker::Number.number([6,7,8,9].sample)
-#   d = Development.new( name: name, address: address, status: status, total_cost: total_cost, creator: User.all.sample )
+#   d = Development.new(name: name, address: address, status: status, total_cost: total_cost, creator: User.all.sample)
 #   assert_creation(d)
 # end
 

--- a/test/controllers/api/v1/developments_controller_test.rb
+++ b/test/controllers/api/v1/developments_controller_test.rb
@@ -11,7 +11,7 @@ class API::V1::DevelopmentsControllerTest < ActionController::TestCase
   end
 
   test 'should get index, filtering on range' do
-    get :index, filter: { commsf: "[11,13]" }
+    get :index, filter: { commsf: '[11,13]' }
     assert_equal 1, results(response).count, results(response).inspect
     assert_response :success
   end

--- a/test/controllers/searches_controller_test.rb
+++ b/test/controllers/searches_controller_test.rb
@@ -12,7 +12,7 @@ class SearchesControllerTest < ActionController::TestCase
   end
 
   test 'saves searches when reporting on them' do
-    assert_difference "Search.where(saved: true).count", +1 do
+    assert_difference 'Search.where(saved: true).count', +1 do
       get :show, id: search.id
     end
   end

--- a/test/controllers/searches_controller_test.rb
+++ b/test/controllers/searches_controller_test.rb
@@ -6,15 +6,22 @@ class SearchesControllerTest < ActionController::TestCase
   end
 
   test 'should get show' do
-    get :show, id: search.id
+    get :show, id: search.id, format: :html
     assert_response :success
     assert assigns(:search)
   end
 
   test 'saves searches when reporting on them' do
     assert_difference 'Search.where(saved: true).count', +1 do
-      get :show, id: search.id
+      get :show, id: search.id, format: :html
     end
+  end
+
+  test 'renders CSV' do
+    get :show, id: search.id, format: :csv
+    assert_response :success
+    content_type = response.headers["Content-Transfer-Encoding"]
+    assert_equal 'binary', content_type
   end
 
 end

--- a/test/models/broadcast_test.rb
+++ b/test/models/broadcast_test.rb
@@ -75,7 +75,7 @@ class BroadcastTest < ActiveSupport::TestCase
   end
 
   test 'deliver' do
-    skip "No mail yet."
+    skip 'No mail yet.'
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
       broadcast.deliver!
     end
@@ -83,13 +83,13 @@ class BroadcastTest < ActiveSupport::TestCase
   end
 
   test '#schedule!' do
-    # TODO assert_no_difference in the background job queue count
+    # TODO: assert_no_difference in the background job queue count
     broadcast.scheduled_for = 10.days.from_now
     broadcast.schedule!
     assert_equal 'scheduled', broadcast.state
   end
 
   test "can't reschedule a delivered message" do
-    skip "Not yet implemented."
+    skip 'Not yet implemented.'
   end
 end

--- a/test/models/claim_test.rb
+++ b/test/models/claim_test.rb
@@ -107,10 +107,10 @@ class ClaimTest < ActiveSupport::TestCase
   # Needing so many collaboratiors suggests the need for
   # service objects like Claim::Approval and Claim::Denial
   test 'user cannot moderate their own claim unless admin' do
-    skip """
+    skip '''
       Expecting this to fail because we have not yet implemented
       roles like :admin that would help this pass.
-    """
+    '''
     assert_raises(StandardError) {
       claim.approve! moderator: claimant
     }

--- a/test/models/development_test.rb
+++ b/test/models/development_test.rb
@@ -31,7 +31,7 @@ class DevelopmentTest < ActiveSupport::TestCase
   end
 
   test 'attribute read is from an indifferent hash' do
-    skip "Moving attributes out of hash."
+    skip 'Moving attributes out of hash.'
     d.name = 'Godfrey Hotel'
     assert_equal d.fields['name'], d.name
     assert_equal d.fields[:name], d.name
@@ -90,7 +90,7 @@ class DevelopmentTest < ActiveSupport::TestCase
   end
 
   test '#mixed_use?' do
-    skip "Come back to this soon."
+    skip 'Come back to this soon.'
     assert_not Development.new.mixed_use?
     assert_not Development.new(tothu:  1).mixed_use?
     assert_not Development.new(commsf: 1).mixed_use?
@@ -144,7 +144,7 @@ class DevelopmentTest < ActiveSupport::TestCase
 
   test '#crosswalks' do
     org = organizations :mapc
-    d.crosswalks.new(organization: org, internal_id: "1-1")
+    d.crosswalks.new(organization: org, internal_id: '1-1')
     assert_not_empty d.crosswalks
   end
 
@@ -187,7 +187,7 @@ class DevelopmentTest < ActiveSupport::TestCase
 
   test 'contributors includes creator' do
     creator = users(:normal)
-    # TODO clear out edits on this development.
+    # TODO: clear out edits on this development.
     assert d.creator.present?
     assert_includes d.contributors, creator
   end
@@ -255,13 +255,18 @@ class DevelopmentTest < ActiveSupport::TestCase
   def periscope_params
     hash = Hash.new
     ranged_scopes.each { |key| hash[key] = [0,1] }
-    hash.merge({rdv: true, asofright: false, ovr55: nil, clusteros: 'true', phased: 'false', stalled: 'NULL', cancelled: true, hidden: true})
+    hash.merge(mergeable_hash)
   end
 
   def periscope_params_alt
     hash = Hash.new
     ranged_scopes.each { |key| hash[key] = 1_234 }
-    hash.merge({rdv: true, asofright: false, ovr55: nil, clusteros: 'true', phased: 'false', stalled: 'NULL', cancelled: true, hidden: true})
+    hash.merge(mergeable_hash)
+  end
+
+  def mergeable_hash
+    { rdv:   true, asofright: false,  phased:  'false', cancelled: true,
+      ovr55: nil,  clusteros: 'true', stalled: 'NULL',  hidden: true }
   end
 
   def ranged_scopes
@@ -282,7 +287,7 @@ class DevelopmentTest < ActiveSupport::TestCase
   end
 
   test 'location' do
-    assert_equal d.location, [71.000001,42.000001]
+    assert_equal d.location, [71.000001, 42.000001]
   end
 
 end

--- a/test/models/field_edit_test.rb
+++ b/test/models/field_edit_test.rb
@@ -33,31 +33,31 @@ class FieldEditTest < ActiveSupport::TestCase
   end
 
   test 'requires a change that has, at least, :to' do
-    field.change = {from: 100, to: 101}
+    field.change = { from: 100, to: 101 }
     assert field.valid?
-    field.change = {to: true}
+    field.change = { to: true }
     assert field.valid?
   end
 
   test 'change :to a non-nil false value' do
-    field.change = {from: true, to: false}
+    field.change = { from: true, to: false }
     assert field.valid?
-    field.change = {from: nil, to: false}
+    field.change = { from: nil, to: false }
     assert field.valid?
-    field.change = {from: false, to: nil}
+    field.change = { from: false, to: nil }
     assert_not field.valid?
   end
 
   test 'change a string to an empty string' do
-    skip "Not yet sure what to do about this."
-    field.change = {from: "x", to: ""}
+    skip 'Not yet sure what to do about this.'
+    field.change = { from: 'x', to: '' }
     assert_not field.valid?
   end
 
   test 'requires a change that is really a change' do
-    field.change = {from: 100, to: 100}
+    field.change = { from: 100, to: 100 }
     assert_not field.valid?
-    field.change = {from: 100, to: 101}
+    field.change = { from: 100, to: 101 }
     assert field.valid?
   end
 
@@ -76,7 +76,7 @@ class FieldEditTest < ActiveSupport::TestCase
   test '#conflict' do
     assert_nil field.conflict
     field.development.commsf = 13
-    expected = {current: 13, from: 12}
+    expected = { current: 13, from: 12 }
     assert_equal expected, field.conflict
   end
 

--- a/test/models/flag_test.rb
+++ b/test/models/flag_test.rb
@@ -38,7 +38,7 @@ class FlagTest < ActiveSupport::TestCase
   end
 
   test "changes moderator's inbox count" do
-    skip "This is a tangential collaborator and does not belong here."
+    skip 'This is a tangential collaborator and does not belong here.'
     assert_difference 'flag.development.moderator.first.inbox.count', +1 do
       flag.save
     end

--- a/test/models/inbox_notice_test.rb
+++ b/test/models/inbox_notice_test.rb
@@ -12,19 +12,22 @@ class InboxNoticeTest < ActiveSupport::TestCase
   end
 
   test 'requires a level' do
-    skip "One of: :info, :warn, :success, :danger"
+    skip 'One of: :info, :warn, :success, :danger'
   end
 
   test 'requires a state' do
-    skip "One of: :pending, :sent, :delivered, :unread, :read"
+    skip 'One of: :pending, :sent, :delivered, :unread, :read'
   end
 
   test 'notifications' do
-    skip "Notification event log, like NotificationEvent :sms, :number, :sent_at"
+    skip """
+      Notification event log, like NotificationEvent
+      :sms, :number, :sent_at
+    """
   end
 
   test 'notified' do
-    skip "If there are any notification events."
+    skip 'If there are any notification events.'
   end
 
   test 'requires a subject line between 15 and 40 characters' do

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -45,7 +45,7 @@ class MembershipTest < ActiveSupport::TestCase
 
   # I think this belongs in a controller test
   test 'member can leave an organization' do
-    skip "For now"
+    skip 'For now'
     user = m.user
     org  = m.organization
 
@@ -57,14 +57,14 @@ class MembershipTest < ActiveSupport::TestCase
   end
 
   # test 'only administrators can promote members' do
-  #   skip "Roles not yet implemented"
+  #   skip 'Roles not yet implemented'
   # end
 
   # test 'administrators are notified when someone leaves the org' do
-  #   skip "Roles and notifications not yet implemented"
+  #   skip 'Roles and notifications not yet implemented'
   # end
 
   # test 'administrators are notified when someone wants in' do
-  #   skip "email, notification / inbox"
+  #   skip 'email, notification / inbox'
   # end
 end

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -41,7 +41,7 @@ class OrganizationTest < ActiveSupport::TestCase
     assert org.valid?
     org.location = 'Boston, MA'
     assert org.valid?
-    org.location = 'Lake Char­gogg­a­gogg­man­chaugg­a­gogg­chau­bun­a­gung­a­maugg / Webster Lake, Webster, Massachusetts, United States of America'
+    org.location =
     assert org.valid?
   end
 
@@ -58,10 +58,10 @@ class OrganizationTest < ActiveSupport::TestCase
   end
 
   test 'requires a URL that exists' do
-    skip """
+    skip '''
       Read https://www.igvita.com/2006/09/07/validating-url-in-ruby-on-rails/
       and http://stackoverflow.com/questions/5908017/check-if-url-exists-in-ruby
-    """
+    '''
     org.website = 'https://lo.lllll'
     assert_not org.valid?
     org.website = 'http://homestarrunner.com'
@@ -69,13 +69,13 @@ class OrganizationTest < ActiveSupport::TestCase
   end
 
   test 'has a log' do
-    skip """
+    skip '''
       Tracks when:
         - A member invites another member.
         - An invited member accepts.
         - A member leaves.
         - A member is kicked out.
-    """
+    '''
   end
 
   test 'can have many members through memberships' do
@@ -99,14 +99,14 @@ class OrganizationTest < ActiveSupport::TestCase
   end
 
   test 'URL template' do
-    org.url_template = "http://www.bostonredevelopmentauthority.org/document-center?project={id}"
+    org.url_template = template('?project={id}')
     expanded = org.url_parser.expand(id: 45)
-    expected = "http://www.bostonredevelopmentauthority.org/document-center?project=45"
+    expected = template('?project=45')
     assert_equal expanded, expected
   end
 
   test 'requires valid URL template' do
-    org.url_template = "http://www.bostonredevelopmentauthority.org/document-center?project="
+    org.url_template = template('?project=')
     assert_not org.valid?
   end
 
@@ -125,5 +125,18 @@ class OrganizationTest < ActiveSupport::TestCase
 
   test 'related developments custom method responds correctly' do
     assert_respond_to(org, :developments)
+  end
+
+  private
+
+  def webster
+    """
+      Lake Char­gogg­a­gogg­man­chaugg­a­gogg­chau­bun­a­gung­a­maugg
+      / Webster Lake, Webster, Massachusetts, United States of America
+    """.strip.gsub(/\s+/, ' ')
+  end
+
+  def template(part)
+    "http://www.bostonredevelopmentauthority.org/document-center#{part}"
   end
 end

--- a/test/models/place_profile_test.rb
+++ b/test/models/place_profile_test.rb
@@ -9,16 +9,16 @@ class PlaceProfileTest < ActiveSupport::TestCase
 
   def geojson
     {
-      "type" => "Polygon",
-      "coordinates" => [
+      'type' => 'Polygon',
+      'coordinates' => [
         [
-          [1.0, 0.0],
-          [0.5000000000000001, 0.8660254037844386],
-          [-0.4999999999999998, 0.8660254037844388],
-          [-1.0, 1.224646799147353e-16],
+          [1.0,                  0.0],
+          [0.5000000000000001,   0.8660254037844386],
+          [-0.4999999999999998,  0.8660254037844388],
+          [-1.0,                 1.224646799147353e-16],
           [-0.5000000000000004, -0.8660254037844384],
-          [0.4999999999999993, -0.866025403784439],
-          [1.0, 0.0]
+          [0.4999999999999993,  -0.866025403784439],
+          [1.0,                  0.0]
         ]
       ]
     }
@@ -59,7 +59,7 @@ class PlaceProfileTest < ActiveSupport::TestCase
   test '#to_point' do
     profile.longitude = 10
     profile.latitude  = 20
-    assert_equal [10,20], profile.to_point
+    assert_equal [10, 20], profile.to_point
   end
 
   test 'coordinates equal named attributes' do

--- a/test/models/search_test.rb
+++ b/test/models/search_test.rb
@@ -8,6 +8,7 @@ class SearchTest < ActiveSupport::TestCase
   def saved_search
     @_saved_search ||= searches(:saved)
   end
+
   alias_method :saved, :saved_search
 
   test 'valid' do
@@ -42,12 +43,12 @@ class SearchTest < ActiveSupport::TestCase
 
   test '#unsaved?' do
     assert search.unsaved?
-    refute  saved.unsaved?
+    refute saved.unsaved?
   end
 
   test '#saved?' do
     refute search.saved?
-    assert  saved.saved?
+    assert saved.saved?
   end
 
   test 'autogenerates a title if saved:true' do

--- a/test/presenters/change_presenter_test.rb
+++ b/test/presenters/change_presenter_test.rb
@@ -1,49 +1,53 @@
 require 'test_helper'
 
 class ChangePresenterTest < ActiveSupport::TestCase
+
   def presenter
     @_presenter ||= ChangePresenter.new(field_edits(:one))
   end
+
   def item
     presenter.item
   end
+
   alias_method :pres, :presenter
 
   test 'numbers' do
-    item.change = {from: 100.0, to: 200}
-    assert_equal "changed Commercial Square Feet from 100.0 to 200.0", pres.text
-    item.change = {from: 200, to: nil}
-    assert_equal "changed Commercial Square Feet from 200 to 0", pres.text
-    item.change = {from: nil, to: 200}
-    assert_equal "changed Commercial Square Feet from 0 to 200", pres.text
+    item.change = { from: 100.0, to: 200 }
+    assert_equal 'changed Commercial Square Feet from 100.0 to 200.0', pres.text
+    item.change = { from: 200, to: nil }
+    assert_equal 'changed Commercial Square Feet from 200 to 0', pres.text
+    item.change = { from: nil, to: 200 }
+    assert_equal 'changed Commercial Square Feet from 0 to 200', pres.text
   end
 
   test 'booleans' do
-    item.change = {from: true, to: false}
-    assert_equal "set Commercial Square Feet to false", pres.text
-    item.change = {from: false, to: true}
-    assert_equal "set Commercial Square Feet to true", pres.text
-    item.change = {from: nil, to: true}
-    assert_equal "set Commercial Square Feet to true", pres.text
-    item.change = {from: true, to: nil}
-    assert_equal "set Commercial Square Feet to false", pres.text
+    item.change = { from: true, to: false }
+    assert_equal 'set Commercial Square Feet to false', pres.text
+    item.change = { from: false, to: true }
+    assert_equal 'set Commercial Square Feet to true', pres.text
+    item.change = { from: nil, to: true }
+    assert_equal 'set Commercial Square Feet to true', pres.text
+    item.change = { from: true, to: nil }
+    assert_equal 'set Commercial Square Feet to false', pres.text
   end
 
   test 'strings' do
-    item.change = {from: "Godfrey", to: "The Godfrey."}
-    assert_equal "changed Commercial Square Feet from 'Godfrey' to 'The Godfrey.'", pres.text
+    item.change = { from: 'Godfrey', to: 'The Godfrey.' }
+    expect = "changed Commercial Square Feet from 'Godfrey' to 'The Godfrey.'"
+    assert_equal expect, pres.text
   end
 
   test 'unexpected' do
-    item.change = {from: Class, to: Object}
+    item.change = { from: Class, to: Object }
     assert_raises(ArgumentError) { pres.text }
   end
 
   test 'changeable attributes have human names' do
     development = developments(:one)
-    attributes = development.attributes.select{ |_k,v| !v.is_a? String }
-    deletable_attributes.each{ |key| attributes.delete(key) }
-    attributes.each_pair do |key, value|
+    attributes = development.attributes.select { |_k, v| !v.is_a? String }
+    deletable_attributes.each { |key| attributes.delete(key) }
+    attributes.each_pair do |key, _v|
       expected = key.to_s.titleize
       actual = Development.human_attribute_name(key)
       refute_equal expected, actual
@@ -51,7 +55,8 @@ class ChangePresenterTest < ActiveSupport::TestCase
   end
 
   def deletable_attributes
-    %w( id city state creator_id fields phased stalled status height
-       stories total_cost private latitude longitude )
+    %w( id   state   creator_id fields  phased   status stalled
+        city stories total_cost private latitude height longitude )
   end
+
 end

--- a/test/presenters/development_presenter_test.rb
+++ b/test/presenters/development_presenter_test.rb
@@ -1,12 +1,15 @@
 require 'test_helper'
 
 class DevelopmentPresenterTest < ActiveSupport::TestCase
+
   def presenter
     @_presenter ||= DevelopmentPresenter.new(developments(:one))
   end
+
   def item
     presenter.item
   end
+
   alias_method :pres, :presenter
 
   test '#contributors' do
@@ -74,12 +77,12 @@ class DevelopmentPresenterTest < ActiveSupport::TestCase
   end
 
   test 'address' do
-    expected = "505 Washington Street, Boston MA 02111"
+    expected = '505 Washington Street, Boston MA 02111'
     assert_equal expected, pres.display_address
   end
 
   test 'short address' do
-    expected = "505 Washington Street, Boston"
+    expected = '505 Washington Street, Boston'
     assert_equal expected, pres.display_address(short: true)
   end
 

--- a/test/presenters/edit_presenter_test.rb
+++ b/test/presenters/edit_presenter_test.rb
@@ -1,12 +1,15 @@
 require 'test_helper'
 
 class EditPresenterTest < ActiveSupport::TestCase
+
   def presenter
     @_presenter ||= EditPresenter.new(edits(:one))
   end
+
   def item
     presenter.item
   end
+
   alias_method :pres, :presenter
 
   test '#editor is presented' do
@@ -21,10 +24,10 @@ class EditPresenterTest < ActiveSupport::TestCase
   test '#time_ago' do
     item.applied_at = 10.hours.ago
     item.applied = true
-    assert_equal "about 10 hours ago", pres.time_ago
+    assert_equal 'about 10 hours ago', pres.time_ago
     item.applied = false
     # Options are for slow-running tests on Travis CI
-    time_options = ["less than a minute ago", "1 minute ago"]
+    time_options = ['less than a minute ago', '1 minute ago']
     assert_includes time_options, pres.time_ago
   end
 

--- a/test/presenters/report_presenter_test.rb
+++ b/test/presenters/report_presenter_test.rb
@@ -53,6 +53,13 @@ class ReportPresenterTest < ActiveSupport::TestCase
       assert_equal report.statuses.send(status), report.send(status)
     end
   end
+
+  test 'to CSV' do
+    csv = report.to_csv
+    assert_equal 'id,', csv[0..2]
+    assert_equal 5, csv.lines.count
+  end
+
 end
 
 # # booleans

--- a/test/presenters/status_info_test.rb
+++ b/test/presenters/status_info_test.rb
@@ -1,36 +1,36 @@
 require 'test_helper'
 
 class StatusInfoTest < ActiveSupport::TestCase
+
   def presenter
     @_presenter ||= StatusInfo.new(developments(:one))
   end
+
   def item
     presenter.item
   end
+
   alias_method :pres, :presenter
 
   test '#status_with_year' do
     Time.stub :now, Time.new(2000) do
       item.year_compl = 2100
-      { projected:       "Projected (for 2100-2110)",
-        planning:        "Planning (est. 2100-2110)",
-        in_construction: "In Construction (est. 2100-2110)",
-        completed:       "Completed (2100)" }.each_pair do |status, text|
-          item.status = status
-          assert_equal text, pres.status_with_year
+      statuses.each_pair do |status, text|
+        item.status = status
+        assert_equal text, pres.status_with_year
       end
     end
   end
 
   test 'year or year range' do
     Time.stub :now, Time.new(2000) do
-      [{year: 2000, expected: '2000'     },
-       {year: 2009, expected: '2009'     },
-       {year: 2010, expected: '2010-2020'},
-       {year: 2011, expected: '2010-2020'},
-       {year: 1989, expected: '1989'     },
-       {year: 2100, expected: '2100-2110'},
-       {year: 2099, expected: '2090-2100'}].each do |set|
+      [{ year: 2000, expected: '2000'      },
+       { year: 2009, expected: '2009'      },
+       { year: 2010, expected: '2010-2020' },
+       { year: 2011, expected: '2010-2020' },
+       { year: 1989, expected: '1989'      },
+       { year: 2100, expected: '2100-2110' },
+       { year: 2099, expected: '2090-2100' }].each do |set|
         item.year_compl = set[:year]
         assert_equal set[:expected], pres.year
       end
@@ -40,6 +40,13 @@ class StatusInfoTest < ActiveSupport::TestCase
   test 'status icon' do
     item.status = :projected
     assert_equal :find,  pres.status_icon
+  end
+
+  def statuses
+    { projected:       'Projected (for 2100-2110)',
+      planning:        'Planning (est. 2100-2110)',
+      in_construction: 'In Construction (est. 2100-2110)',
+      completed:       'Completed (2100)' }
   end
 
 end

--- a/test/presenters/user_presenter_test.rb
+++ b/test/presenters/user_presenter_test.rb
@@ -1,12 +1,15 @@
 require 'test_helper'
 
 class UserPresenterTest < ActiveSupport::TestCase
+
   def presenter
     @_presenter ||= UserPresenter.new(users(:lower_case))
   end
+
   def item
     presenter.item
   end
+
   alias_method :pres, :presenter
 
   test 'first name and last name' do

--- a/test/routes/route_test.rb
+++ b/test/routes/route_test.rb
@@ -3,31 +3,32 @@ require 'test_helper'
 class RouteTest < ActionDispatch::IntegrationTest
   test 'root' do
     skip
-    assert_routing '/', {controller: 'developments', action: 'index'}
+    assert_routing '/', { controller: 'developments', action: 'index' }
   end
 
   test 'default api version' do
-    assert_routing('http://api.test.host/searches',
-      {subdomain: 'api', controller: 'api/v1/searches', action: 'index'})
+    rte = { subdomain: 'api', controller: 'api/v1/searches', action: 'index' }
+    assert_routing('http://api.test.host/searches', rte)
   end
 
   test 'api version parameter' do
-    assert_routing('http://api.test.host/searches?api_version=1',
-      {subdomain: 'api', controller: 'api/v1/searches', action: 'index'})
+    rte = { subdomain: 'api', controller: 'api/v1/searches', action: 'index' }
+    assert_routing('http://api.test.host/searches?api_version=1', rte)
   end
 
   test 'api version in header' do
-    ActionDispatch::TestRequest::DEFAULT_ENV['action_dispatch.request.accepts'] = 'application/org.dd.v1'
-    assert_routing('http://api.test.host/searches',
-      {subdomain: 'api', controller: 'api/v1/searches', action: 'index'})
+    env = ActionDispatch::TestRequest::DEFAULT_ENV
+    env['action_dispatch.request.accepts'] = 'application/org.dd.v1'
+    rte = { subdomain: 'api', controller: 'api/v1/searches', action: 'index' }
+    assert_routing('http://api.test.host/searches', rte)
   end
 
   test 'wildcard after search' do
-    assert_routing('http://test.host/developments/search',
-      {controller: 'developments', action: 'search'})
-    assert_routing('http://test.host/developments/search/map',
-      {controller: 'developments', action: 'search', ui: 'map'})
-    assert_routing('http://test.host/developments/search/list',
-      {controller: 'developments', action: 'search', ui: 'list'})
+    rte = { controller: 'developments', action: 'search' }
+    assert_routing('http://test.host/developments/search', rte)
+    map_rte = { controller: 'developments', action: 'search', ui: 'map' }
+    assert_routing('http://test.host/developments/search/map', map_rte)
+    list_rte = { controller: 'developments', action: 'search', ui: 'list' }
+    assert_routing('http://test.host/developments/search/list', list_rte)
   end
 end

--- a/test/serializers/development_serializer_test.rb
+++ b/test/serializers/development_serializer_test.rb
@@ -1,9 +1,10 @@
 require 'test_helper'
 
 class DevelopmentSerializerTest < ActiveSupport::TestCase
+
   def development
     @_d ||= Development.create!(
-      id: 101010, name: 'Gadfly Hotel', address: '505 Washington Street',
+      id: 101_010, name: 'Gadfly Hotel', address: '505 Washington Street',
       city: 'Boston', state: 'MA', zip_code: '02111', status: 'in_construction',
       commsf: 12, estemp: 75, private: true,
       created_at: Time.new('1969-12-31 19:00:00 -0500'),
@@ -48,7 +49,7 @@ class DevelopmentSerializerTest < ActiveSupport::TestCase
   end
 
   test '#to_row includes development team' do
-    assert_includes dev.to_row, "landlord"
+    assert_includes dev.to_row, 'landlord'
   end
 
   test '#to_header with an #attribute-less object' do
@@ -61,8 +62,8 @@ class DevelopmentSerializerTest < ActiveSupport::TestCase
   end
 
   test '#to_header shows development team' do
-    assert_includes dev.to_header, "team_member_1_name"
-    assert_includes dev.to_header, "team_member_1_role"
+    assert_includes dev.to_header, 'team_member_1_name'
+    assert_includes dev.to_header, 'team_member_1_role'
   end
 
   test 'can allow (only) certain attributes' do
@@ -79,30 +80,30 @@ class DevelopmentSerializerTest < ActiveSupport::TestCase
 
   private
 
-    def expected_row
-      [101010, 562391268, '1969-01-01 05:00:00 UTC', '1969-01-01 05:00:00 UTC',
-       nil, nil, nil, nil, nil, nil, 'Gadfly Hotel', 'in_construction', nil,
-       nil, nil, 'Luxury hotel with ground-floor retail.',
-       '505 Washington Street', 'Boston', 'MA', '02111', nil, nil, 2016, nil,
-       nil, nil, nil, nil, nil, nil, nil, 75, 12, nil, nil, nil, nil, false,
-       true, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-       'Metropolitan Area Planning Council', 'http://mapc.org', nil,
-       'Boston, MA', nil, 'MAPC', 'MAPC', 'landlord']
-    end
+  def expected_row
+    [101_010, 562_391_268, '1969-01-01 05:00:00 UTC', '1969-01-01 05:00:00 UTC',
+     nil, nil, nil, nil, nil, nil, 'Gadfly Hotel', 'in_construction', nil,
+     nil, nil, 'Luxury hotel with ground-floor retail.',
+     '505 Washington Street', 'Boston', 'MA', '02111', nil, nil, 2016, nil,
+     nil, nil, nil, nil, nil, nil, nil, 75, 12, nil, nil, nil, nil, false,
+     true, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+     'Metropolitan Area Planning Council', 'http://mapc.org', nil,
+     'Boston, MA', nil, 'MAPC', 'MAPC', 'landlord']
+  end
 
-    def expected_header
-      %w( id creator_id created_at updated_at rdv asofright ovr55
-          clusteros phased stalled name status desc project_url
-          mapc_notes tagline address city state zip_code height
-          stories year_compl prjarea singfamhu twnhsmmult lgmultifam
-          tothu gqpop rptdemp emploss estemp commsf hotelrms
-          onsitepark total_cost team_membership_count cancelled
-          private fa_ret fa_ofcmd fa_indmf fa_whs fa_rnd fa_edinst
-          fa_other fa_hotel other_rate affordable latitude longitude
-          team_member_1_name team_member_1_website
-          team_member_1_url_template team_member_1_location
-          team_member_1_email team_member_1_abbv
-          team_member_1_short_name team_member_1_role )
-    end
+  def expected_header
+    %w( id creator_id created_at updated_at rdv asofright ovr55
+        clusteros phased stalled name status desc project_url
+        mapc_notes tagline address city state zip_code height
+        stories year_compl prjarea singfamhu twnhsmmult lgmultifam
+        tothu gqpop rptdemp emploss estemp commsf hotelrms
+        onsitepark total_cost team_membership_count cancelled
+        private fa_ret fa_ofcmd fa_indmf fa_whs fa_rnd fa_edinst
+        fa_other fa_hotel other_rate affordable latitude longitude
+        team_member_1_name team_member_1_website
+        team_member_1_url_template team_member_1_location
+        team_member_1_email team_member_1_abbv
+        team_member_1_short_name team_member_1_role )
+  end
 
 end

--- a/test/serializers/development_team_serializer_test.rb
+++ b/test/serializers/development_team_serializer_test.rb
@@ -18,8 +18,8 @@ class DevelopmentTeamSerializerTest < ActiveSupport::TestCase
   test '#to_header with more projects' do
     header = niner.to_header
     assert_equal 72, header.compact.count # to avoid nils
-    assert_equal "team_member_1_name", header.first
-    assert_equal "team_member_9_role", header.last
+    assert_equal 'team_member_1_name', header.first
+    assert_equal 'team_member_9_role', header.last
   end
 
   test '#to_row' do
@@ -37,14 +37,14 @@ class DevelopmentTeamSerializerTest < ActiveSupport::TestCase
   private
 
     def csv_row
-      ["Metropolitan Area Planning Council", "http://mapc.org", nil, "Boston, MA", nil, "MAPC", "MAPC", "landlord"]
+      ['Metropolitan Area Planning Council', 'http://mapc.org', nil, 'Boston, MA', nil, 'MAPC', 'MAPC', 'landlord']
     end
 
     def one_team_member_csv_header
-      ["team_member_1_name", "team_member_1_website",
-       "team_member_1_url_template", "team_member_1_location",
-       "team_member_1_email", "team_member_1_abbv",
-       "team_member_1_short_name", "team_member_1_role"]
+      ['team_member_1_name', 'team_member_1_website',
+       'team_member_1_url_template', 'team_member_1_location',
+       'team_member_1_email', 'team_member_1_abbv',
+       'team_member_1_short_name', 'team_member_1_role']
     end
 
 end

--- a/test/serializers/developments_serializer_test.rb
+++ b/test/serializers/developments_serializer_test.rb
@@ -3,13 +3,13 @@ require 'test_helper'
 class DevelopmentsSerializerTest < ActiveSupport::TestCase
   def development_one
     @_d1 ||= Development.create!(
-      id: 101010, name: 'Gadfly Hotel',
+      id: 101_010, name: 'Gadfly Hotel',
       address: '505 Washington Street', city: 'Boston', state: 'MA',
       zip_code: '02111', status: 'in_construction', commsf: 12,
       estemp: 75, private: true,
       created_at: Time.new('1969-12-31 19:00:00 -0500'),
       updated_at: Time.new('1969-12-31 19:00:00 -0500'),
-      year_compl: 2016, creator: users(:normal)
+      year_compl: '2016', creator: users(:normal)
     )
     @_d1.team_memberships = [DevelopmentTeamMembership.create(
       development: @_d1, role: 'landlord', organization: organizations(:mapc)
@@ -20,12 +20,12 @@ class DevelopmentsSerializerTest < ActiveSupport::TestCase
 
   def development_two
     @_d2 ||= Development.create!(
-      id: 101011, name: 'Hello',
+      id: 101_011, name: 'Hello',
       address: "It's me / I was wondering if after all these years",
       city: "you'd like to me", state: 'ET', zip_code: '02118',
-      status: 'completed', commsf: 200, estemp: 1000, private: false,
+      status: 'completed', commsf: 200, estemp: 1_000, private: false,
       created_at: Time.new('1969-12-31 19:00:00 -0500'),
-      updated_at: Time.new('1969-12-31 19:00:00 -0500'), year_compl: 2012,
+      updated_at: Time.new('1969-12-31 19:00:00 -0500'), year_compl: '2012',
       creator: users(:tim)
     )
   end
@@ -62,28 +62,27 @@ class DevelopmentsSerializerTest < ActiveSupport::TestCase
 
   private
 
-    def expected_csv
-      csv = <<-CSV
+  def expected_csv
+    <<-CSV
 id,creator_id,created_at,updated_at,rdv,asofright,ovr55,clusteros,phased,stalled,name,status,desc,project_url,mapc_notes,tagline,address,city,state,zip_code,height,stories,year_compl,prjarea,singfamhu,twnhsmmult,lgmultifam,tothu,gqpop,rptdemp,emploss,estemp,commsf,hotelrms,onsitepark,total_cost,team_membership_count,cancelled,private,fa_ret,fa_ofcmd,fa_indmf,fa_whs,fa_rnd,fa_edinst,fa_other,fa_hotel,other_rate,affordable,latitude,longitude,team_member_1_name,team_member_1_website,team_member_1_url_template,team_member_1_location,team_member_1_email,team_member_1_abbv,team_member_1_short_name,team_member_1_role
 101010,562391268,1969-01-01 05:00:00 UTC,1969-01-01 05:00:00 UTC,,,,,,,Gadfly Hotel,in_construction,,,,Luxury hotel with ground-floor retail.,505 Washington Street,Boston,MA,02111,,,2016,,,,,,,,,75,12,,,,1,false,true,,,,,,,,,,,,,Metropolitan Area Planning Council,http://mapc.org,,\"Boston, MA\",,MAPC,MAPC,landlord
 101011,730190997,1969-01-01 05:00:00 UTC,1969-01-01 05:00:00 UTC,,,,,,,Hello,completed,,,,Luxury hotel with ground-floor retail.,It's me / I was wondering if after all these years,you'd like to me,ET,02118,,,2012,,,,,,,,,1000,200,,,,,false,false,,,,,,,,,,,,,,,,,,,,
-      CSV
-    end
+    CSV
+  end
 
+  def expected_header
+    %w( id creator_id created_at updated_at rdv asofright ovr55
+        clusteros phased stalled name status desc project_url
+        mapc_notes tagline address city state zip_code height
+        stories year_compl prjarea singfamhu twnhsmmult lgmultifam
+        tothu gqpop rptdemp emploss estemp commsf hotelrms
+        onsitepark total_cost team_membership_count cancelled
+        private fa_ret fa_ofcmd fa_indmf fa_whs fa_rnd fa_edinst
+        fa_other fa_hotel other_rate affordable latitude longitude
+        team_member_1_name team_member_1_website
+        team_member_1_url_template team_member_1_location
+        team_member_1_email team_member_1_abbv
+        team_member_1_short_name team_member_1_role )
+  end
 
-
-    def expected_header
-      %w( id creator_id created_at updated_at rdv asofright ovr55
-          clusteros phased stalled name status desc project_url
-          mapc_notes tagline address city state zip_code height
-          stories year_compl prjarea singfamhu twnhsmmult lgmultifam
-          tothu gqpop rptdemp emploss estemp commsf hotelrms
-          onsitepark total_cost team_membership_count cancelled
-          private fa_ret fa_ofcmd fa_indmf fa_whs fa_rnd fa_edinst
-          fa_other fa_hotel other_rate affordable latitude longitude
-          team_member_1_name team_member_1_website
-          team_member_1_url_template team_member_1_location
-          team_member_1_email team_member_1_abbv
-          team_member_1_short_name team_member_1_role )
-    end
 end

--- a/test/services/edit_application_test.rb
+++ b/test/services/edit_application_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class EditApplicationTest < ActiveSupport::TestCase
   def application
-    @_application ||= EditApplication.new( edits(:one) )
+    @_application ||= EditApplication.new(edits(:one))
   end
 
   def edit
@@ -45,14 +45,14 @@ class EditApplicationTest < ActiveSupport::TestCase
   end
 
   test 'perform! when conflict returns false' do
-    conflict = EditApplication.new( edits(:conflict) )
+    conflict = EditApplication.new(edits(:conflict))
     refute conflict.perform! # Should not change anything
     assert_equal 'pending', conflict.edit.state
     assert_equal 12, conflict.development.commsf
   end
 
   test 'ignore conflict and apply edit' do
-    conflict = EditApplication.new( edits(:conflict) )
+    conflict = EditApplication.new(edits(:conflict))
     refute conflict.perform!
     conflict.edit.ignore_conflicts = true
     conflict.perform!

--- a/test/services/edit_approval_test.rb
+++ b/test/services/edit_approval_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class EditApprovalTest < ActiveSupport::TestCase
   def approval
-    @_approval ||= EditApproval.new( edits(:one) )
+    @_approval ||= EditApproval.new(edits(:one))
   end
 
   def edit
@@ -19,7 +19,7 @@ class EditApprovalTest < ActiveSupport::TestCase
 
   test 'raises with invalid edit' do
     assert_raises(StandardError) do
-      EditApproval.new( Edit.new )
+      EditApproval.new(Edit.new)
     end
   end
 

--- a/test/services/tagline_generator_test.rb
+++ b/test/services/tagline_generator_test.rb
@@ -15,7 +15,7 @@ class TaglineGeneratorTest < ActiveSupport::TestCase
   end
 
   test 'performed' do
-    assert_match /luxury hotel/i, perform
+    assert_match(/luxury hotel/i, perform)
   end
 
 end

--- a/test/support/session_helpers.rb
+++ b/test/support/session_helpers.rb
@@ -1,23 +1,21 @@
 module SessionHelpers
 
-  def sign_up_with(email, password, options={})
+  def sign_up_with(email, password, options = {})
     visit  = options.fetch(:visit) { false }
     submit = options.fetch(:submit) { false }
 
     visit signup_path if visit
 
-    fill_in 'Email', with: email
-    fill_in 'Password',      with: password
+    fill_in 'Email',    with: email
+    fill_in 'Password', with: password
     fill_in 'Password confirmation', with: password
     click_button 'Sign up' if submit
   end
 
-  def sign_in(user, options={})
+  def sign_in(user, options = {})
     visit signin_path if options.fetch(:visit, false)
-    fill_in 'Email',
-      with: options.fetch(:email) { user.email }
-    fill_in 'Password',
-      with: options.fetch(:password) { user.password }
+    fill_in 'Email',    with: options.fetch(:email)    { user.email }
+    fill_in 'Password', with: options.fetch(:password) { user.password }
     check_remember_box(options)
     click_button 'Log in' if options.fetch(:submit, false)
   end
@@ -27,14 +25,14 @@ module SessionHelpers
     click_link 'Sign out'
   end
 
-  def request_password_reset_for(user, options={})
+  def request_password_reset_for(user, options = {})
     visit new_password_reset_path
     fill_in 'Email', with: options.fetch(:email) { user.email }
     click_button 'Request password reset'
   end
 
-  def set_password(options={})
-    password = options.fetch(:password) { 'v4lidp4ssw0rd' }
+  def set_password(options = {})
+    password = options.fetch(:password)     { 'v4lidp4ssw0rd' }
     confirm  = options.fetch(:confirmation) { password }
     fill_in 'Password',              with: password
     fill_in 'Password confirmation', with: confirm
@@ -43,13 +41,10 @@ module SessionHelpers
 
   private
 
-    def check_remember_box(options={})
+    def check_remember_box(options = {})
+      box = 'Remember me'
       checked = options.fetch(:remember) { true }
-      if checked
-        check 'Remember me'
-      else
-        uncheck 'Remember me'
-      end
+      checked ? check(box) : uncheck(box)
     end
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,20 +1,20 @@
-ENV["RAILS_ENV"] = "test"
+ENV['RAILS_ENV'] = 'test'
 if ENV['CODECLIMATE_REPO_TOKEN']
-  require "codeclimate-test-reporter"
+  require 'codeclimate-test-reporter'
   CodeClimate::TestReporter.start
 end
 
-require File.expand_path("../../config/environment", __FILE__)
+require File.expand_path('../../config/environment', __FILE__)
 
-require "rails/test_help"
+require 'rails/test_help'
 %w( rails rails/capybara hell reporters focus ).each { |lib|
   require "minitest/#{lib}"
 }
-require "minitest/benchmark" if ENV["BENCH"]
-require "minitest/fail_fast" if ENV["FAST"]
+require 'minitest/benchmark' if ENV['BENCH']
+require 'minitest/fail_fast' if ENV['FAST']
 
 # Require entire support tree
-Dir[File.expand_path("test/support/**/*")].each { |file| require file }
+Dir[File.expand_path('test/support/**/*')].each { |file| require file }
 
 Minitest::Reporters.use!(
   # Progress bar


### PR DESCRIPTION
Why:

Hound was catching a lot of style errors and wasn't recognizing one
of my style definitions (extra spaces around class/module definition).
I decided to download Rubocop to audit the style locally and debug
the issue that way.

When I discovered Rubocop was catching over 1000 style violations, I
decided to spend some time working on the style.

This change addresses the need by:

Removing ~500 style issues.

There are still over 500 style issues remaining, including some seeming
bugs with multiline strings. I may also disable the "don't use curly
braces for multiline blocks", but would prefer configuring this to check
to make sure there's only 3 lines.