### PR TITLE
Deflect development/update to proposed edit

### DIFF
--- a/app/controllers/api/v1/developments_controller.rb
+++ b/app/controllers/api/v1/developments_controller.rb
@@ -1,10 +1,30 @@
 module API
   module V1
     class DevelopmentsController < APIController
-      before_action :restrict_access, only: [:create]
-      after_action :log_search, only: [:index]
+      before_action :restrict_access, only: [:create, :update]
+      after_action  :log_search, only: [:index]
+
+      def update
+        development = Development.find(params[:id])
+        persist! development if development.present? # WARN: NilCheck
+        render nothing: true, status: :ok
+      end
 
       private
+
+      def persist!(development)
+        # Without a transaction, this can become a dangling edit with
+        # no changes, which causes an error in our timid pending edits template.
+        ActiveRecord::Base.transaction do
+          edit = development.edits.create!(editor: current_user)
+          development.changes.each_pair do |name, diff|
+            edit.fields.create!(
+              name:   name,
+              change: { from: diff.first, to: diff.last }
+            )
+          end
+        end
+      end
 
       def log_search
         if filter_params.keys.any?

--- a/app/models/concerns/development/field_aliases.rb
+++ b/app/models/concerns/development/field_aliases.rb
@@ -3,6 +3,11 @@ class Development
     extend ActiveSupport::Concern
 
     included do
+      alias_attribute :redevelopment,  :rdv
+      alias_attribute :as_of_right,    :asofright
+      alias_attribute :age_restricted, :ovr55
+      alias_attribute :cluster_or_open_space_development, :clusteros
+
       alias_attribute :description, :desc
       alias_attribute :website,     :project_url
       alias_attribute :zip,         :zip_code

--- a/test/controllers/api/v1/developments_controller_test.rb
+++ b/test/controllers/api/v1/developments_controller_test.rb
@@ -30,7 +30,7 @@ class API::V1::DevelopmentsControllerTest < ActionController::TestCase
   end
 
   test 'should get index, filtering on range' do
-    get :index, filter: { commsf: '[11,13]' }
+    get :index, filter: { estemp: '[50,100]' }
     assert_equal 1, results(response).count, results(response).inspect
     assert_response :success
   end
@@ -44,14 +44,14 @@ class API::V1::DevelopmentsControllerTest < ActionController::TestCase
   end
 
   test 'should get index, filtering on status' do
-    get :index, filter: { status: 'in_construction' }
+    get :index, filter: { status: 'planning' }
     assert_response :success
     assert_equal 1, results(response).count
   end
 
   test 'should log non-blank searches' do
     assert_difference 'Search.count', +2 do
-      get :index, filter: { commsf: '[11,13]' }
+      get :index, filter: { estemp: '[50,100]' }
       get :index, filter: { rdv: 'true' }
     end
   end
@@ -80,7 +80,7 @@ class API::V1::DevelopmentsControllerTest < ActionController::TestCase
     stub_walkscore(lat: 42.3, lon: -71.0)
 
     post :create, create_development_json
-    assert_response :created, response.body
+    assert_response :created, JSON.parse(response.body)#['errors'].first['meta']['backtrace'].join("\n")
   end
 
   test 'should not create unauthorized user' do
@@ -91,6 +91,7 @@ class API::V1::DevelopmentsControllerTest < ActionController::TestCase
 
   test 'should update' do
     set_content_type_header!
+    set_auth_header_for_user! user
     assert_difference 'Edit.pending.count', +1 do
       patch :update, id: developments(:one), data: update_development_payload
     end
@@ -98,7 +99,9 @@ class API::V1::DevelopmentsControllerTest < ActionController::TestCase
   end
 
   test 'should not update with unauthorized user' do
-    skip 'come back to this'
+    set_content_type_header!
+    patch :update, id: developments(:one), data: update_development_payload
+    assert_response :unauthorized, response.body
   end
 
   test 'should not destroy' do
@@ -123,7 +126,9 @@ class API::V1::DevelopmentsControllerTest < ActionController::TestCase
           name: '100 Fury Road',
           description: ('a' * 142),
           'year-compl' => 2106,
-          'street-view-latitude' => 42.301,
+          tothu: 0,
+          commsf: 0,
+          'street-view-latitude'  =>  42.301,
           'street-view-longitude' => -71.010
         }
       }


### PR DESCRIPTION
Why:

With the Ember interface, we need to update developments through the
API, but the API wants to update the resource directly. We need to
deflect the call, creating a proposed edit based on the changes.

Tests were failing because we took attribute aliases out of the
resource, intending to redefine them in the model's FieldAliases module,
but never actually redefined them.

This change addresses the need by:

* Propose an edit instead of updating the development, and render
nothing successfully. This isn't as good as redirecting to another API
action like edits/show, but it's hard to figuring out how to override
the controller actions.

* Redefining attribute aliases.

* Changing tests to catch up to fixtures.