### PR TITLE
Make custom PATCH developments meet spec

### DIFF
--- a/app/controllers/api/v1/developments_controller.rb
+++ b/app/controllers/api/v1/developments_controller.rb
@@ -6,8 +6,13 @@ module API
 
       def update
         development = Development.find(params[:id])
-        persist! development if development.present? # WARN: NilCheck
-        render nothing: true, status: :ok
+        if development.present? # WARN: NilCheck
+          persist! development
+          # Serialize object like a GET request, according to spec
+          render json: JSONAPI::ResourceSerializer.new(DevelopmentResource).
+            serialize_to_hash(DevelopmentResource.new(development, nil)),
+            content_type: JSONAPI::MEDIA_TYPE
+        end
       end
 
       private

--- a/app/resources/api/v1/development_resource.rb
+++ b/app/resources/api/v1/development_resource.rb
@@ -7,7 +7,9 @@ module API
       attributes :name, :status, :tagline, :description, :project_url,
                  :year_compl,
 
-                 :mixed_use, :redevelopment, :as_of_right, :age_restricted,
+                 :mixed_use, :rdv, :asofright, :ovr55, :clusteros, :hidden,
+
+                 :redevelopment, :as_of_right, :age_restricted,
                  :cluster_or_open_space_development, :phased, :stalled,
                  :cancelled, :private,
 

--- a/test/controllers/api/v1/developments_controller_test.rb
+++ b/test/controllers/api/v1/developments_controller_test.rb
@@ -89,12 +89,15 @@ class API::V1::DevelopmentsControllerTest < ActionController::TestCase
     assert_response :unauthorized
   end
 
-  test 'should update' do
+  test 'should update and return object' do
     set_content_type_header!
     set_auth_header_for_user! user
     assert_difference 'Edit.pending.count', +1 do
       patch :update, id: developments(:one), data: update_development_payload
     end
+    # Shouldn't change the name, since it goes into moderation
+    assert_equal 'Godfrey Hotel', results(response)['attributes']['name']
+    assert_includes response.headers['Content-Type'], 'application/vnd.api+json'
     assert_response :success, response.body
   end
 
@@ -151,7 +154,7 @@ class API::V1::DevelopmentsControllerTest < ActionController::TestCase
 
   def stub_street_view
     file = ActiveRecord::FixtureSet.file('street_view/godfrey.jpg')
-    stub_request(:get, 'http://maps.googleapis.com/maps/api/streetview?fov=100&heading=35&key=loLOLol&location=42.301,-71.01&pitch=28&size=600x600').
+    stub_request(:get, 'http://maps.googleapis.com/maps/api/streetview?fov=100&heading=0&key=loLOLol&location=42.301,-71.01&pitch=35&size=600x600').
       to_return(status: 200, body: file)
   end
 


### PR DESCRIPTION
Why:

As part of the hack to get edits into moderation, I had set
developments/update to render nothing with an OK status. Ember,
following the JSONAPI spec, didn't like this.

This change addresses the need by:

* Serializing and rendering the development properly.

* Setting the correct content type.