### PR TITLE
Fix subdomain, add email

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -8,7 +8,8 @@ class Subscription < ActiveRecord::Base
   validate :valid_subscribable
 
   def needs_update?
-    subscribable.updated_since?(user.last_checked_subscriptions)
+    return false unless subscribable
+    subscribable.updated_since? user.last_checked_subscriptions
   end
 
   private

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,7 +77,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  DEFAULT_HOST = ENV.fetch 'HOST', 'dd.mapc.org'
+  DEFAULT_HOST = ENV.fetch 'DEFAULT_HOST', 'dd.mapc.org'
   Rails.application.default_url_options[:host] = DEFAULT_HOST
 
   config.action_mailer.delivery_method = :smtp

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,5 +81,14 @@ Rails.application.configure do
   Rails.application.default_url_options[:host] = DEFAULT_HOST
 
   config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    port:            ENV['MAILGUN_SMTP_PORT'],
+    address:         ENV['MAILGUN_SMTP_SERVER'],
+    user_name:       ENV['MAILGUN_SMTP_LOGIN'],
+    password:        ENV['MAILGUN_SMTP_PASSWORD'],
+    domain:          ENV['MAILGUN_DOMAIN']
+    authentication:  :plain
+  }
+
   config.action_mailer.default_url_options = { host: DEFAULT_HOST }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,7 +86,7 @@ Rails.application.configure do
     address:         ENV['MAILGUN_SMTP_SERVER'],
     user_name:       ENV['MAILGUN_SMTP_LOGIN'],
     password:        ENV['MAILGUN_SMTP_PASSWORD'],
-    domain:          ENV['MAILGUN_DOMAIN']
+    domain:          ENV['MAILGUN_DOMAIN'],
     authentication:  :plain
   }
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'no-reply@mapc.org'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 require 'api_version'
+require 'subdomain_constraint'
 
 Rails.application.routes.draw do
 
@@ -12,7 +13,7 @@ Rails.application.routes.draw do
     action:     'new',
     as:         :new_development
 
-  namespace :api, constraints: { subdomain: 'api' }, path: '' do
+  namespace :api, constraints: SubdomainConstraint.new(/^api/), path: '' do
     api_version(APIVersion.new(version: 1, default: true).params) do
       jsonapi_resources :developments,  except: [:destroy]
       jsonapi_resources :searches,      only: [:index, :show, :create, :destroy]

--- a/lib/subdomain_constraint.rb
+++ b/lib/subdomain_constraint.rb
@@ -1,0 +1,9 @@
+class SubdomainConstraint
+  def initialize(subdomain)
+    @subdomain = subdomain
+  end
+
+  def matches?(request)
+    @subdomain.match request.host
+  end
+end

--- a/public/500.html
+++ b/public/500.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Oh no! 404!</title>
+  <title>Sorry! (Internal Server Error)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" media="screen" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.8/components/reset.min.css" />
   <link rel="stylesheet" media="screen" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.8/components/site.min.css" />


### PR DESCRIPTION
* Add subdomain constraint so 'api' has to be the first part of the domain, not just the only subdomain.
* Add email settings.
* Fix the title on the 500 error page.