### PR TITLE
Fix Walk Score, nearest transit, and layout

### DIFF
--- a/app/models/concerns/development/model_callbacks.rb
+++ b/app/models/concerns/development/model_callbacks.rb
@@ -7,7 +7,8 @@ class Development
       before_save :associate_place
       before_save :determine_mixed_use
       before_save :cache_street_view
-      before_save :update_walk_score
+      before_save :update_walkscore
+      before_save :update_nearest_transit
       before_save :estimate_employment
 
       private
@@ -40,9 +41,15 @@ class Development
         end
       end
 
-      def update_walk_score
+      def update_walkscore
         if location_fields_changed? || new_record?
-          self.walkscore = WalkScore.new(lat: latitude, lon: longitude).to_h
+          self.get_walkscore
+        end
+      end
+
+      def update_nearest_transit
+        if location_fields_changed? || new_record?
+          self.get_nearest_transit
         end
       end
 

--- a/app/models/street_view.rb
+++ b/app/models/street_view.rb
@@ -1,3 +1,5 @@
+require 'compass'
+
 class StreetView
 
   attr_reader :url
@@ -27,12 +29,19 @@ class StreetView
   end
 
   def null?
-    hash == self.class.null
+    self.class.null.include? hash
   end
 
   # This image means we're over the rate limit.
   def self.null
-    "18bd8a05483bcc612f0891f94364d410"
+    [
+      "18bd8a05483bcc612f0891f94364d410",  # Rate-limited
+      "f4af83d510a83d5c480ecebe1cedaf6d"   # No imagery here
+    ]
+  end
+
+  def compass_direction
+    Compass.direction_from_degrees(heading)
   end
 
   private

--- a/app/presenters/development_presenter.rb
+++ b/app/presenters/development_presenter.rb
@@ -113,7 +113,7 @@ class DevelopmentPresenter < Burgundy::Item
 
   def categorized_attributes
     { physical:   [:tothu, :commsf, :prjarea, :stories, :height],
-      housing:    [:singfamhu, :twnhsmmult, :lgmultifam, :tothu],
+      housing:    [:singfamhu, :twnhsmmult, :lgmultifam],
       commercial: [:fa_ret, :fa_ofcmd, :fa_indmf, :fa_whs, :fa_rnd,
         :fa_edinst, :fa_other, :fa_hotel] }
   end

--- a/app/views/developments/show.html.haml
+++ b/app/views/developments/show.html.haml
@@ -22,17 +22,15 @@
 
 .row
   .ten.wide.column
-    #images
-      = render partial: 'developments/show/street_view'
     #data
-      .ui.horizontal.divider Details
       = render partial: 'developments/show/physical'
+      = render partial: 'developments/show/transportation'
       = render partial: 'developments/show/residential'
       = render partial: 'developments/show/commercial'
-      -# = render partial: 'developments/show/transportation'
 
   .six.wide.column#sidebar
     #map-container= render partial: 'developments/show/map'
+    #images=  render partial: 'developments/show/street_view'
     #team=    render partial: 'developments/show/team'
     #contrib= render partial: 'developments/show/contributors'
     #related= render partial: 'developments/show/related'

--- a/app/views/developments/show/_commercial.html.haml
+++ b/app/views/developments/show/_commercial.html.haml
@@ -12,7 +12,7 @@
     about business and commerce at this development.
 
 - if @development.commercial_attributes.any?
-  %table.ui.basic.selectable.celled.table
+  %table.ui.selectable.celled.table
     %thead
       %th
         %h4.ui.header
@@ -34,15 +34,24 @@
       - if @development.commsf.to_i > 0
         - @development.commercial_attributes.each_pair do |field, value|
           = render partial: 'developments/show/row', locals: { field: field,
-            value: value, conditional: true,
-            extra: number_to_percentage(value/@development.commsf.to_i * 100,
-              precision: 0) }
+            value: value,
+            conditional: true,
+            extra: number_to_percentage(value/@development.commsf.to_i * 100, precision: 0) }
 
-      = render partial: 'developments/show/row', locals: { field: :commsf,
-          value: @development.commsf, conditional: false, unit: 'sqft',
-          extra: '100%' }
+    %tfoot
+      %tr
+        %th
+          %h4.ui.header
+            .content
+              = Development.human_attribute_name(:commsf)
+              Total
+        %th
+          = number_with_delimiter(@development.commsf.to_i)
+        %th
+          100%
 
-  %table.ui.very.basic.selectable.celled.table
+
+  %table.ui.basic.selectable.celled.table
     %tbody
       = render partial: 'developments/show/row',
           locals: { field: :hotelrms, conditional: true,
@@ -51,7 +60,7 @@
   %h3.ui.header
     Employment
 
-  %table.ui.very.basic.selectable.celled.table
+  %table.ui.basic.selectable.celled.table
     %tbody
       = render partial: 'developments/show/row', locals: { field: :employment,
           conditional: true, subheader: @development.employment_type }

--- a/app/views/developments/show/_history.html.haml
+++ b/app/views/developments/show/_history.html.haml
@@ -2,6 +2,10 @@
 .ui.small.feed
   %h4.ui.header Recent Changes
   - if @development.recent_history.empty?
+    .ui.basic.label
+      Last Updated
+      .detail
+      = @development.created_at.to_s(:short)
     .event
       .content
         There is no activity to show.

--- a/app/views/developments/show/_physical.html.haml
+++ b/app/views/developments/show/_physical.html.haml
@@ -1,7 +1,6 @@
-%h3.ui.header
-  Building &amp; Site
-  .sub.header
-    Physical Attributes
+.ui.horizontal.divider Building & Site
+
+.ui.horizontal.divider
 
 - if @development.physical_attributes.empty?
   -# TODO: Contribution button partial
@@ -19,13 +18,3 @@
           .value= value
           .label
             = Development.human_attribute_name(field)
-
-    - unless @development.walkscore.empty?
-      .ui.statistic
-        .value
-          = link_to @development.walkscore.to_h['help_link'], target: '_blank' do
-            = @development.walkscore.score
-        .label
-          = link_to @development.walkscore.to_h['help_link'], target: '_blank' do
-            WalkScore &reg;
-

--- a/app/views/developments/show/_residential.html.haml
+++ b/app/views/developments/show/_residential.html.haml
@@ -12,7 +12,7 @@
     about housing for this development.
 
 - if @development.housing_attributes.any?
-  %table.ui.basic.selectable.celled.table
+  %table.ui.selectable.celled.table
     %thead
       %th
         %h4.ui.header
@@ -26,8 +26,16 @@
       - @development.housing_attributes.each_pair do |field, value|
         = render partial: 'developments/show/row', locals: { field: field,
             value: value, conditional: true }
+    %tfoot
+      %tr
+        %th
+          %h4.ui.header
+            .content
+              = Development.human_attribute_name(:tothu)
+        %th
+          = number_with_delimiter(@development.tothu.to_i)
 
-  %table.ui.very.basic.selectable.celled.table
+  %table.ui.basic.selectable.celled.table
     %tbody
       = render partial: 'developments/show/row', locals: { field: :gqpop,
         conditional: true, subheader: 'i.e. dorms, barracks, etc.' }

--- a/app/views/developments/show/_row.html.haml
+++ b/app/views/developments/show/_row.html.haml
@@ -1,11 +1,11 @@
 :ruby
   conditional = local_assigns.fetch(:conditional, false)
-  subheader = local_assigns.fetch(:subheader, nil)
-  content = local_assigns.fetch(:content, nil)
-  extra = local_assigns.fetch(:extra, nil)
-  value = local_assigns.fetch(:value, @development.send(field))
-  unit = local_assigns.fetch(:unit, nil)
-  widths = extra ? %w(six five five) : %w(ten six)
+  subheader   = local_assigns.fetch(:subheader, nil)
+  content     = local_assigns.fetch(:content, nil)
+  extra       = local_assigns.fetch(:extra, nil)
+  value       = local_assigns.fetch(:value, @development.send(field))
+  unit        = local_assigns.fetch(:unit, nil)
+  widths      = extra ? %w(six five five) : %w(ten six)
 
 - if conditional && value.nil?
   -# NO OP

--- a/app/views/developments/show/_street_view.html.haml
+++ b/app/views/developments/show/_street_view.html.haml
@@ -1,7 +1,27 @@
 :ruby
   src = @development.street_view.data
-  style = 'width: 600px; height: 600px;'
+  style = 'width: 100%;'
   alt = @development.name
 
 - unless @development.street_view.null?
-  %img.ui.image{ src: src, style: style, alt: alt }
+  .ui.horizontal.divider
+  .ui.fluid.card
+    .image
+      %img{ src: src, alt: alt }
+    .content
+      .description
+        %p
+          Google Street View for
+          = succeed ',' do
+            = @development.address
+          facing
+          = succeed '.' do
+            = @development.street_view.compass_direction
+          %p
+            = link_to edit_development_path(@development) do
+              %i.pencil.icon
+              Edit Street View
+    .extra.content
+      %i.warning.icon
+      Image may be old, or not oriented toward the site.
+

--- a/app/views/developments/show/_transportation.html.haml
+++ b/app/views/developments/show/_transportation.html.haml
@@ -1,24 +1,24 @@
-%h3.ui.header
-  Transportation
-  .sub.header
-    Transit, Parking, and Walking
+-# %h3.ui.header
+-#   Transportation
+-#   .sub.header
+-#     Transit, Parking, and Walking
 
-.ui.tiny.statistics
+.ui.horizontal.divider
 
-  .ui.green.statistic
-    .label
-      Walk Score
-    .value
-      93
+.ui.large.basic.label#parking
+  %i.car.icon
+  = @development.onsitepark
+  on-site parking spaces
 
-  .ui.statistic
-    .value
-      25
-    .label
-      Parking Spaces
-
-.ui.mini.red.statistic
-  .value
-    Charles / MGH
-  .label
+- if @development.nearest_transit.present?
+  .ui.large.basic.label#transit
     Nearest Transit Station
+    .detail
+      = @development.nearest_transit
+
+- unless @development.walkscore.empty?
+  = link_to @development.walkscore.to_h['help_link'], target: '_blank' do
+    .ui.large.basic.label
+      = @development.walkscore.score
+      .detail
+        WalkScore &reg;

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -6,6 +6,14 @@ Time::DATE_FORMATS[:subject] = proc { |date|
   date.stamp('Sunday, 2 Feb 2016')
 }
 
+Time::DATE_FORMATS[:short] = proc { |date|
+  date.stamp('Feb 2, 1999')
+}
+
+Date::DATE_FORMATS[:short] = proc { |date|
+  date.stamp('Feb 2, 1999')
+}
+
 Date::DATE_FORMATS[:subject] = proc { |date|
   date.stamp('Sunday, 2 Feb 2016')
 }

--- a/db/migrate/20160615155856_add_nearest_transit_to_development.rb
+++ b/db/migrate/20160615155856_add_nearest_transit_to_development.rb
@@ -1,0 +1,5 @@
+class AddNearestTransitToDevelopment < ActiveRecord::Migration
+  def change
+    add_column :developments, :nearest_transit, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -276,7 +276,8 @@ CREATE TABLE developments (
     street_view_image bytea,
     parcel_id character varying(25),
     walkscore json DEFAULT '{}'::json NOT NULL,
-    mixed_use boolean
+    mixed_use boolean,
+    nearest_transit character varying
 );
 
 
@@ -1605,4 +1606,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160526150247');
 INSERT INTO schema_migrations (version) VALUES ('20160613151630');
 
 INSERT INTO schema_migrations (version) VALUES ('20160614162551');
+
+INSERT INTO schema_migrations (version) VALUES ('20160615155856');
 

--- a/lib/compass.rb
+++ b/lib/compass.rb
@@ -1,0 +1,42 @@
+module Compass
+  def self.direction_from_degrees(degrees)
+    case degrees
+    when 348.75...360
+      'N'
+    when 0...11.25
+      'N'
+    when 11.25...33.75
+      'NNE'
+    when 33.75...56.25
+      'NE'
+    when 56.25...78.75
+      'ENE'
+    when 78.75...101.25
+      'E'
+    when 101.25...123.75
+      'ESE'
+    when 123.75...146.25
+      'SE'
+    when 146.25...168.75
+      'SSE'
+    when 168.75...191.25
+      'S'
+    when 191.25...213.75
+      'SSW'
+    when 213.75...236.25
+      'SW'
+    when 236.25...258.75
+      'WSW'
+    when 258.75...281.25
+      'W'
+    when 281.25...303.75
+      'WNW'
+    when 303.75...326.25
+      'NW'
+    when 326.25...348.75
+      'NNW'
+    else
+      '?'
+    end
+  end
+end

--- a/lib/walk_score.rb
+++ b/lib/walk_score.rb
@@ -1,19 +1,22 @@
 class WalkScore
 
   BASE_URL = 'http://api.walkscore.com/score?format=json'.freeze
-  API_KEY = ENV['WALKSCORE_API_KEY']
 
-  def initialize(lat: nil, lon: nil, hash: {})
-    @content ||= if hash
-      hash
+  attr_reader :content
+
+  # Pass in content if we're trying to wrap and not look up live values.
+  # Pass in a lat and lon if we're trying to get a live value.
+  def initialize(lat: nil, lon: nil, content: nil)
+    @content ||= if content
+      content
     else
-      @lat, @lon = lat, lon
+      @lat, @lon = lat.to_f, lon.to_f
       JSON.parse(response).with_indifferent_access
     end
   end
 
   def score
-    @content[:walkscore]
+    @content['walkscore']
   end
 
   def to_h
@@ -29,7 +32,7 @@ class WalkScore
   end
 
   def url
-    "#{BASE_URL}&lat=#{@lat}&lon=#{@lon}&wsapikey=#{API_KEY}"
+    "#{BASE_URL}&lat=#{@lat}&lon=#{@lon}&wsapikey=#{ENV['WALKSCORE_API_KEY']}"
   end
 
 end

--- a/test/fixtures/mbta/stopsbylocation.json
+++ b/test/fixtures/mbta/stopsbylocation.json
@@ -1,0 +1,125 @@
+{
+
+  "stop": [{
+    "stop_id": "70159",
+    "stop_name": "Boylston - Outbound",
+    "parent_station": "place-boyls",
+    "parent_station_name": "Boylston",
+    "stop_lat": "42.35302",
+    "stop_lon": "-71.06459",
+    "distance": "0.00800655130296946"
+  }, {
+    "stop_id": "70158",
+    "stop_name": "Boylston - Inbound",
+    "parent_station": "place-boyls",
+    "parent_station_name": "Boylston",
+    "stop_lat": "42.35302",
+    "stop_lon": "-71.06459",
+    "distance": "0.00800655130296946"
+  }, {
+    "stop_id": "place-boyls",
+    "stop_name": "Boylston",
+    "parent_station": "",
+    "parent_station_name": "",
+    "stop_lat": "42.35302",
+    "stop_lon": "-71.06459",
+    "distance": "0.00800655130296946"
+  }, {
+    "stop_id": "8279",
+    "stop_name": "Tremont St @ Boylston Station",
+    "parent_station": "",
+    "parent_station_name": "",
+    "stop_lat": "42.353247",
+    "stop_lon": "-71.064353",
+    "distance": "0.0277116596698761"
+  }, {
+    "stop_id": "70019",
+    "stop_name": "Chinatown - Inbound",
+    "parent_station": "place-chncl",
+    "parent_station_name": "Chinatown",
+    "stop_lat": "42.352547",
+    "stop_lon": "-71.062752",
+    "distance": "0.100191049277782"
+  }, {
+    "stop_id": "70018",
+    "stop_name": "Chinatown - Outbound",
+    "parent_station": "place-chncl",
+    "parent_station_name": "Chinatown",
+    "stop_lat": "42.352547",
+    "stop_lon": "-71.062752",
+    "distance": "0.100191049277782"
+  }, {
+    "stop_id": "place-chncl",
+    "stop_name": "Chinatown",
+    "parent_station": "",
+    "parent_station_name": "",
+    "stop_lat": "42.352547",
+    "stop_lon": "-71.062752",
+    "distance": "0.100191049277782"
+  }, {
+    "stop_id": "6567",
+    "stop_name": "Washington St @ Essex St",
+    "parent_station": "",
+    "parent_station_name": "",
+    "stop_lat": "42.352461",
+    "stop_lon": "-71.062552",
+    "distance": "0.11149089038372"
+  }, {
+    "stop_id": "6537",
+    "stop_name": "Washington St @ Essex St",
+    "parent_station": "",
+    "parent_station_name": "",
+    "stop_lat": "42.352288",
+    "stop_lon": "-71.062581",
+    "distance": "0.114014588296413"
+  }, {
+    "stop_id": "91856",
+    "stop_name": "Stuart St @ Tremont St",
+    "parent_station": "",
+    "parent_station_name": "",
+    "stop_lat": "42.351136",
+    "stop_lon": "-71.064763",
+    "distance": "0.122894078493118"
+  }, {
+    "stop_id": "1241",
+    "stop_name": "Charles St S @ Park Plaza",
+    "parent_station": "",
+    "parent_station_name": "",
+    "stop_lat": "42.351748",
+    "stop_lon": "-71.067101",
+    "distance": "0.148577779531479"
+  }, {
+    "stop_id": "6542",
+    "stop_name": "Kneeland St @ Washington St",
+    "parent_station": "",
+    "parent_station_name": "",
+    "stop_lat": "42.350845",
+    "stop_lon": "-71.062868",
+    "distance": "0.16936793923378"
+  }, {
+    "stop_id": "9983",
+    "stop_name": "Stuart St @ Charles St S",
+    "parent_station": "",
+    "parent_station_name": "",
+    "stop_lat": "42.351039",
+    "stop_lon": "-71.066798",
+    "distance": "0.169407889246941"
+  }, {
+    "stop_id": "8281",
+    "stop_name": "285 Tremont St",
+    "parent_station": "",
+    "parent_station_name": "",
+    "stop_lat": "42.350087",
+    "stop_lon": "-71.065251",
+    "distance": "0.19760525226593"
+  }, {
+    "stop_id": "49001",
+    "stop_name": "Temple Pl @ Washington St",
+    "parent_station": "",
+    "parent_station_name": "",
+    "stop_lat": "42.355385",
+    "stop_lon": "-71.062211",
+    "distance": "0.211329147219658"
+  }]
+
+}


### PR DESCRIPTION
Why:

After a demo with Tim, we found that WalkScore, parking spaces, and
nearest transit station were missing.

We also decided that Street View was taking up too much page space, and
might confuse people if it was oriented incorrectly. Also, images that
say "no image for this area" weren't being caught when we asked if the
Street View is null.

This change addresses the need by:

* Fixed a bug with WalkScore, where passing an option to :hash would
cause it to not be updated.

* Added an MBTA transit station lookup. If there are no major transit
stations, it uses the nearest bus stop.

* Alter layout, moving Street View to the sidebar and adding context to
help the user understand it's not perfect.

* Add 'no images in this location' to the list of null street view
images, so it doesn't display on the show page.

* Added "Last Updated" to empty "Recent Changes" feeds.

* Gave tables footers for rows that represent totals.