### PR TITLE
Move Places toward top of search.

### DIFF
--- a/app/resources/api/v1/searchable_resource.rb
+++ b/app/resources/api/v1/searchable_resource.rb
@@ -8,17 +8,35 @@ module API
       key_type :string
 
       def self.find_by_key(text, options = {})
-        search_results = PgSearch.multisearch(text).limit(5).
+        search_results = PgSearch.multisearch(text).
+          where(searchable_type: 'Development').limit(5).
           map(&:searchable).
           map { |record| wrap_with_resource(record) }
-        location = MapzenSearch.new(text).result || null
-        if location.properties['confidence'] > 0.75
-          search_results.unshift LocationResource.new(location, context: {})
-        end
+        loc = MapzenSearch.new(text).result || null
+        search_results.unshift place_resource(text) if no_place?(search_results)
+        search_results.unshift location_resource(loc) if confident_in_location?(loc)
         search_results
       end
 
       private
+
+      def self.location_resource(location)
+        LocationResource.new(location, context: {})
+      end
+
+      def self.confident_in_location?(location)
+        location.properties['confidence'] > 0.75
+      end
+
+      def self.place_resource(text)
+        PlaceResource.new(
+          Place.like(text).first, context: {}
+        )
+      end
+
+      def self.no_place?(search_results)
+        search_results.select { |r| r.is_a?(PlaceResource) }.empty?
+      end
 
       def self.null
         OpenStruct.new(geometry: {}, properties: { 'confidence' => 0 })


### PR DESCRIPTION
Why:

Searching for "Bedford", for example, didn't return desired results --
to see that municipality. Now, we put the matching municipality on top
of the search results.